### PR TITLE
Fix exchange retransmission on slow network

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,3 +9,4 @@ Add support for WiFi / Bluetooth / Thread commisionning
 Add IPv6 support
 Make it compatible with a web API to use it in a browser / webview
 Add support for QName compression in DnsCodec
+Review message ack / retransmission logic: doesn't handle well slow requests as is


### PR DESCRIPTION
Message retransmission acks were randomly breaking the connection.
This only happened on slow local network or if one of the two devices is slow to respond.

The whole message exchange logic is not 100% correct and the code is hairy to follow, so this whole class should probably be rewritten in the future...