### PR TITLE
Returns undefined when no IP on the interface on Node implementation

### DIFF
--- a/src/net/node/NetworkNode.ts
+++ b/src/net/node/NetworkNode.ts
@@ -49,6 +49,6 @@ export class NetworkNode extends Network {
                 return {ip: address, mac};
             }
         }
-        throw new Error(`Cannot find the device IP on the subnet containing ${remoteAddress}`);
+        return undefined;
     }
 }


### PR DESCRIPTION
On the previous fix, I wrote an unit test to ensure this fix, however the unit test is using the fake implementation of the network provider and I forgot to update the node implementation.