### PR TITLE
[Matter 1.0 update] Allow standalone acks mid-exchange 

### DIFF
--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -10,6 +10,7 @@ import { Session } from "../session/Session";
 import { Channel } from "../../net/Channel";
 import { MessageType } from "../session/secure/SecureChannelMessages";
 import { MessageCounter } from "./ExchangeManager";
+import { getPromiseResolver } from "../../util/Promises";
 
 class MessageChannel<ContextT> implements Channel<Message> {
     constructor(
@@ -29,14 +30,6 @@ class MessageChannel<ContextT> implements Channel<Message> {
 }
 
 export class MessageExchange<ContextT> {
-    readonly channel: MessageChannel<ContextT>;
-    private readonly activeRetransmissionTimeoutMs: number;
-    private readonly retransmissionRetries: number;
-    private readonly messagesQueue = new Queue<Message>();
-    private receivedMessageToAck: Message | undefined;
-    private sentMessageToAck: Message | undefined;
-    private retransmissionTimeoutId:  NodeJS.Timeout | undefined;
-
     static fromInitialMessage<ContextT>(
         session: Session<ContextT>,
         channel: Channel<Buffer>,
@@ -82,6 +75,16 @@ export class MessageExchange<ContextT> {
         );
     }
 
+    readonly channel: MessageChannel<ContextT>;
+    private readonly activeRetransmissionTimeoutMs: number;
+    private readonly retransmissionRetries: number;
+    private readonly messagesQueue = new Queue<Message>();
+    private receivedMessageToAck: Message | undefined;
+    private sentMessageToAck: Message | undefined;
+    private sentMessageAckSuccess: (() => void) | undefined;
+    private sentMessageAckFailure: (() => void) | undefined;
+    private retransmissionTimeoutId:  NodeJS.Timeout | undefined;
+
     constructor(
         readonly session: Session<ContextT>,
         channel: Channel<Buffer>,
@@ -95,7 +98,7 @@ export class MessageExchange<ContextT> {
         private readonly closeCallback: () => void,
     ) {
         this.channel = new MessageChannel(channel, session);
-        const {activeRetransmissionTimeoutMs: activeRetransmissionTimeoutMs, retransmissionRetries} = session.getMrpParameters();
+        const {activeRetransmissionTimeoutMs, idleRetransmissionTimeoutMs, retransmissionRetries} = session.getMrpParameters();
         this.activeRetransmissionTimeoutMs = activeRetransmissionTimeoutMs;
         this.retransmissionRetries = retransmissionRetries;
     }
@@ -114,21 +117,16 @@ export class MessageExchange<ContextT> {
             this.channel.send(this.sentMessageToAck);
             return;
         }
-        if (ackedMessageId !== undefined && this.sentMessageToAck?.packetHeader.messageId !== ackedMessageId) {
-            // Received an unexpected ack, might be for a message retransmission, ignoring
-            return;
-        }
         if (this.sentMessageToAck !== undefined) {
             if (ackedMessageId === undefined) throw new Error("Previous message ack is missing");
+            if (ackedMessageId !== this.sentMessageToAck.packetHeader.messageId) throw new Error("Incorrect ack received");
             // The other side has received our previous message
+            this.sentMessageAckSuccess?.();
             this.sentMessageToAck = undefined;
             clearTimeout(this.retransmissionTimeoutId);
         }
         if (messageType === MessageType.StandaloneAck) {
-            // This indicates the end of this message exchange
-            if (requiresAck) throw new Error("Standalone acks should not require an ack");
-            // Wait some time before closing this exchange to handle potential retransmissions
-            setTimeout(() => this.closeInternal(), this.activeRetransmissionTimeoutMs * 3);
+            // Don't include standalone acks in the message stream
             return;
         }
         if (requiresAck) {
@@ -137,7 +135,7 @@ export class MessageExchange<ContextT> {
         this.messagesQueue.write(message);
     }
 
-    send(messageType: number, payload: Buffer) {
+    async send(messageType: number, payload: Buffer) {
         if (this.sentMessageToAck !== undefined) throw new Error("The previous message has not been acked yet, cannot send a new message");
         const message = {
             packetHeader: {
@@ -158,10 +156,22 @@ export class MessageExchange<ContextT> {
             payload,
         };
         this.receivedMessageToAck = undefined;
-        this.sentMessageToAck = message;
-        this.retransmissionTimeoutId = setTimeout(() => this.retransmitMessage(message, 0), this.activeRetransmissionTimeoutMs);
+        let ackPromise: Promise<void> | undefined;
+        if (message.payloadHeader.requiresAck) {
+            this.sentMessageToAck = message;
+            this.retransmissionTimeoutId = setTimeout(() => this.retransmitMessage(message, 0), this.activeRetransmissionTimeoutMs);
+            const { promise, resolver, rejecter } = await getPromiseResolver<void>();
+            this.sentMessageAckSuccess = resolver;
+            this.sentMessageAckFailure = rejecter;
+        }
 
-        return this.channel.send(message);
+        await this.channel.send(message);
+
+        if (ackPromise !== undefined) {
+            await ackPromise;
+            this.sentMessageAckFailure = undefined;
+            this.sentMessageAckFailure = undefined;
+        }
     }
 
     nextMessage() {
@@ -187,11 +197,12 @@ export class MessageExchange<ContextT> {
         if (this.receivedMessageToAck !== undefined) {
             this.send(MessageType.StandaloneAck, Buffer.alloc(0));
         }
-        setTimeout(() => this.closeInternal(), this.activeRetransmissionTimeoutMs * 3);
+        setTimeout(() => this.closeInternal(), this.activeRetransmissionTimeoutMs * (this.retransmissionRetries + 1));
     }
 
     private closeInternal() {
         clearTimeout(this.retransmissionTimeoutId);
+        this.sentMessageAckFailure?.();
         this.messagesQueue.close();
         this.closeCallback();
     }

--- a/src/matter/session/secure/CaseClient.ts
+++ b/src/matter/session/secure/CaseClient.ts
@@ -85,6 +85,7 @@ export class CaseClient {
             resumptionRecord = {fabric, peerNodeId, sharedSecret, resumptionId: peerResumptionId };
         }
 
+        messenger.close();
         client.saveResumptionRecord(resumptionRecord);
 
         return secureSession;

--- a/src/matter/session/secure/CaseServer.ts
+++ b/src/matter/session/secure/CaseServer.ts
@@ -93,6 +93,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             resumptionRecord = { peerNodeId, fabric, sharedSecret, resumptionId };
         }
 
+        messenger.close();
         server.saveResumptionRecord(resumptionRecord);
     }
 }

--- a/src/matter/session/secure/PaseClient.ts
+++ b/src/matter/session/secure/PaseClient.ts
@@ -38,6 +38,7 @@ export class PaseClient {
         // All good! Creating the secure session
         await messenger.waitForSuccess();
         const secureSession = await client.createSecureSession(sessionId, UNDEFINED_NODE_ID, UNDEFINED_NODE_ID, peerSessionId, Ke, Buffer.alloc(0), true);
+        messenger.close();
         console.log(`Pase client: Paired succesfully with ${messenger.getChannelName()}`);
 
         return secureSession;

--- a/src/matter/session/secure/PaseServer.ts
+++ b/src/matter/session/secure/PaseServer.ts
@@ -58,6 +58,7 @@ export class PaseServer implements ProtocolHandler<MatterDevice> {
         // All good! Creating the secure session
         await server.createSecureSession(sessionId, UNDEFINED_NODE_ID, UNDEFINED_NODE_ID, peerSessionId, Ke, Buffer.alloc(0), false, mrpParameters?.idleRetransTimeoutMs, mrpParameters?.activeRetransTimeoutMs);
         await messenger.sendSuccess();
+        messenger.close();
         console.log(`Pase server: Paired succesfully with ${messenger.getChannelName()}`);
     }
 }

--- a/src/matter/session/secure/SecureChannelMessenger.ts
+++ b/src/matter/session/secure/SecureChannelMessenger.ts
@@ -50,6 +50,10 @@ export class SecureChannelMessenger<ContextT> {
         return this.exchange.channel.channel.getName();
     }
 
+    close() {
+        this.exchange.close();
+    }
+
     private async sendStatusReport(generalStatus: GeneralStatusCode, protocolStatus: ProtocolStatusCode) {
         const buffer = new LEBufferWriter();
         buffer.writeUInt16(generalStatus);


### PR DESCRIPTION
Matter now sends standalone message acks for long running operations in the middle of the message exchange.

Previously standalone acks were only used at the end of the stream, so the code was using it to detect the end of the stream, logic broken by Matter 1.0 update.