### PR TITLE
OnOff Cluster implementation

### DIFF
--- a/src/matter/cluster/OnOffCluster.ts
+++ b/src/matter/cluster/OnOffCluster.ts
@@ -8,34 +8,62 @@ import { BooleanT, Field, ObjectT, StringT, Template, UnsignedIntT, UnsignedLong
 import { Attribute, OptionalAttribute, OptionalWritableAttribute, Cluster, Command, NoArgumentsT, NoResponseT } from "./Cluster";
 import { TlvType } from "../../codec/TlvCodec";
 
-export const enum OnOffStartUpOnOff {
+
+// From [Matter Application Cluster Specification R1.0], section 1.5.5.1
+// If the value is null, the OnOff attribute is set to its previous value when the device starts up.
+export const enum StartUpOnOff {
+    /**
+     * Set the OnOff attribute to FALSE when the device starts up.
+     */
     Off = 0,
+    /**
+     * Set the OnOff attribute to TRUE when the device starts up.
+     */
     On = 1,
+    /**
+     * If the previous value of the OnOff attribute is equal to FALSE, set the OnOff
+     * attribute to TRUE. If the previous value of the OnOff attribute is equal to TRUE,
+     * set the OnOff attribute to FALSE (toggle).
+     */
     Toggle = 2,
 }
-const OnOffStartUpOnOffT = { tlvType: TlvType.UnsignedInt } as Template<OnOffStartUpOnOff>;
+const StartUpOnOffT = { tlvType: TlvType.UnsignedInt } as Template<StartUpOnOff>;
 
-export const enum OnOffEffectIdentifier {
+// From [Matter Application Cluster Specification R1.0], section 1.5.7.4.1
+export const enum EffectIdentifier {
     DelayedAllOff = 0,
     DyingLight = 1,
 }
-const OnOffEffectIdentifierT = { tlvType: TlvType.UnsignedInt } as Template<OnOffEffectIdentifier>;
+const EffectIdentifierT = { tlvType: TlvType.UnsignedInt } as Template<EffectIdentifier>;
 
-export const enum OnOffDelayedAllOffEffectVariant {
-    FadeToOffIn_0p8Seconds = 0,
+// From [Matter Application Cluster Specification R1.0], section 1.5.7.4.2
+export const enum DelayedAllOffEffectVariant {
+    /**
+     * Fade to off in 0.8 seconds
+     */
+    Fade = 0,
     NoFade = 1,
-    "50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" = 2,
+    /**
+     * 50% dim down in 0.8 seconds then fade to off in 12 seconds
+     */
+    DimDownThenFade = 2,
 }
-const OnOffDelayedAllOffEffectVariantT = { tlvType: TlvType.UnsignedInt } as Template<OnOffDelayedAllOffEffectVariant>;
+const DelayedAllOffEffectVariantT = { tlvType: TlvType.UnsignedInt } as Template<DelayedAllOffEffectVariant>;
 
-export const enum OnOffDyingLightEffectVariant {
-    "20PercentDimUpIn_0p5SecondsThenFadeToOffIn_1Second" = 0,
+// From [Matter Application Cluster Specification R1.0], section 1.5.7.4.2
+export const enum DyingLightEffectVariant {
+    /**
+     * 20% dim up in 0.5s then fade to off in 1 second
+     */
+    DimUpThenFade = 0,
 }
-const OnOffDyingLightEffectVariantT = { tlvType: TlvType.UnsignedInt } as Template<OnOffDyingLightEffectVariant>;
+const DyingLightEffectVariantT = { tlvType: TlvType.UnsignedInt } as Template<DyingLightEffectVariant>;
 
-const OnOffEffectVariantT = UnsignedIntT as Template<OnOffDyingLightEffectVariant | OnOffDelayedAllOffEffectVariant>;
+// From [Matter Application Cluster Specification R1.0], section 1.5.7.4.2
+const EffectVariantT = UnsignedIntT as Template<DyingLightEffectVariant | DelayedAllOffEffectVariant>;
 
 /*
+// TODO Add Bitfield Type
   <bitmap name="OnOffControl" type="BITMAP8">
     <cluster code="0x0006"/>
     <field name="AcceptOnlyWhenOn" mask="0x01"/>
@@ -43,67 +71,24 @@ const OnOffEffectVariantT = UnsignedIntT as Template<OnOffDyingLightEffectVarian
 */
 
 const OffWithEffectRequestT = ObjectT({
-    effectId: Field(0, OnOffEffectIdentifierT),
-    effectVariant: Field(1, OnOffEffectVariantT),
-});
+    effectIdentifier: Field(0, EffectIdentifierT),
+    effectVariant: Field(1, EffectVariantT),
+}) as Template<
+    { effectIdentifier: EffectIdentifier.DelayedAllOff, effectVariant: DelayedAllOffEffectVariant } |
+    { effectIdentifier: EffectIdentifier.DyingLight, effectVariant: DyingLightEffectVariant }
+    >;
 
 const OnWithTimedOffRequestT = ObjectT({
     onOffControl: Field(0, UnsignedIntT), /* TODO: Type is a Bit map! */
-    onTime: Field(1, UnsignedIntT), /* min:0, max: 254 */
-    offWaitTime: Field(2, UnsignedIntT), /* min:0, max: 254 */
+    onTime: Field(1, UnsignedIntT), /* nullable: true, min:0, max: 254 */
+    offWaitTime: Field(2, UnsignedIntT), /* nullable: true, min:0, max: 254 */
 });
 
-/**
- * Attributes and commands for switching devices between 'On' and 'Off' states.
+/*
+  TODO
+  * Feature map:
+    * Bit 0: Level Control for Lighting - Behavior that supports lighting applications.
  */
-export const OnOffCluster = Cluster(
-    0x06,
-    "On/Off",
-    {
-        onOff: Attribute(0, BooleanT, false), /* reportable: true, scene:true */
-        globalSceneControl: OptionalAttribute(0x4000, BooleanT, true),
-        onTime: OptionalWritableAttribute(0x4001, UnsignedIntT, 0),
-        offWaitTime: OptionalWritableAttribute(0x4002, UnsignedIntT, 0),
-        startUpOnOff: OptionalWritableAttribute(0x4003, OnOffStartUpOnOffT), /* nullable: true, writeAcl: manage */
-    },
-    {
-        /**
-         * On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is
-         * recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime
-         * attribute SHALL be set to 0.
-         */
-        off: Command(0, NoArgumentsT, 0, NoResponseT),
-        /**
-         * On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is
-         * recommended that it is used for power on or similar functions. On receipt of the On command, if the value
-         * of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.
-         */
-        on: Command(1, NoArgumentsT, 1, NoResponseT),
-        /**
-         * On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise,
-         * if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value
-         * of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device
-         * SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime
-         * attribute SHALL be set to 0.
-         */
-        toggle: Command(2, NoArgumentsT, 2, NoResponseT),
-        /**
-         * The OffWithEffect command allows devices to be turned off using enhanced ways of fading.
-         */
-        offWithEffect: Command(0x40, OffWithEffectRequestT, 0x40, NoResponseT), /* optional: true */
-        /**
-         * The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.
-         */
-        onWithRecallGlobalScene: Command(0x41, NoArgumentsT, 0x41, NoResponseT), /* optional: true */
-        /**
-         * The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off
-         * duration so that SHOULD the device be subsequently switched off, further OnWithTimedOff commands, received
-         * during this time, are prevented from turning the devices back on.
-         */
-        onWithTimedOff: Command(0x42, OnWithTimedOffRequestT, 0x42, NoResponseT), /* optional: true */
-    },
-);
-
 /*
 Features:
   <bitmap name="OnOffFeature" type="BITMAP32">
@@ -112,3 +97,62 @@ Features:
   </bitmap>
 
  */
+
+
+/**
+ * From [Matter Application Cluster Specification R1.0], section 1.5
+ * Attributes and commands for switching devices between 'On' and 'Off' states.
+ */
+export const OnOffCluster = Cluster(
+    0x06,
+    "On/Off",
+    {
+        onOff: Attribute(0, BooleanT, false), /* reportable: true, scene:true */
+        globalSceneControl: OptionalAttribute(0x4000, BooleanT, true),
+        onTime: OptionalWritableAttribute(0x4001, UnsignedIntT, 0), /* nullable: true, unit: 1/10s */
+        offWaitTime: OptionalWritableAttribute(0x4002, UnsignedIntT, 0), /* nullable: true, unit: 1/10s */
+        startUpOnOff: OptionalWritableAttribute(0x4003, StartUpOnOffT), /* nullable: true, writeAcl: manage */
+    },
+    {
+        /**
+         * From [Matter Application Cluster Specification R1.0], section 1.5.7.1
+         * On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is
+         * recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime
+         * attribute SHALL be set to 0.
+         */
+        off: Command(0, NoArgumentsT, 0, NoResponseT),
+        /**
+         * From [Matter Application Cluster Specification R1.0], section 1.5.7.2
+         * On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is
+         * recommended that it is used for power on or similar functions. On receipt of the On command, if the value
+         * of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.
+         */
+        on: Command(1, NoArgumentsT, 1, NoResponseT),
+        /**
+         * From [Matter Application Cluster Specification R1.0], section 1.5.7.3
+         * On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise,
+         * if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value
+         * of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device
+         * SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime
+         * attribute SHALL be set to 0.
+         */
+        toggle: Command(2, NoArgumentsT, 2, NoResponseT),
+        /**
+         * From [Matter Application Cluster Specification R1.0], section 1.5.7.4
+         * The OffWithEffect command allows devices to be turned off using enhanced ways of fading.
+         */
+        offWithEffect: Command(0x40, OffWithEffectRequestT, 0x40, NoResponseT), /* optional: true */
+        /**
+         * From [Matter Application Cluster Specification R1.0], section 1.5.7.5
+         * The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.
+         */
+        onWithRecallGlobalScene: Command(0x41, NoArgumentsT, 0x41, NoResponseT), /* optional: true */
+        /**
+         * From [Matter Application Cluster Specification R1.0], section 1.5.7.6
+         * The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off
+         * duration so that SHOULD the device be subsequently switched off, further OnWithTimedOff commands, received
+         * during this time, are prevented from turning the devices back on.
+         */
+        onWithTimedOff: Command(0x42, OnWithTimedOffRequestT, 0x42, NoResponseT), /* optional: true */
+    },
+);

--- a/src/matter/cluster/OnOffCluster.ts
+++ b/src/matter/cluster/OnOffCluster.ts
@@ -4,18 +4,111 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BooleanT } from "../../codec/TlvObjectCodec";
-import { Attribute, Cluster, Command, NoArgumentsT, NoResponseT } from "./Cluster";
+import { BooleanT, Field, ObjectT, StringT, Template, UnsignedIntT, UnsignedLongT } from "../../codec/TlvObjectCodec";
+import { Attribute, OptionalAttribute, OptionalWritableAttribute, Cluster, Command, NoArgumentsT, NoResponseT } from "./Cluster";
+import { TlvType } from "../../codec/TlvCodec";
 
+export const enum OnOffStartUpOnOff {
+    Off = 0,
+    On = 1,
+    Toggle = 2,
+}
+const OnOffStartUpOnOffT = { tlvType: TlvType.UnsignedInt } as Template<OnOffStartUpOnOff>;
+
+export const enum OnOffEffectIdentifier {
+    DelayedAllOff = 0,
+    DyingLight = 1,
+}
+const OnOffEffectIdentifierT = { tlvType: TlvType.UnsignedInt } as Template<OnOffEffectIdentifier>;
+
+export const enum OnOffDelayedAllOffEffectVariant {
+    FadeToOffIn_0p8Seconds = 0,
+    NoFade = 1,
+    "50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" = 2,
+}
+const OnOffDelayedAllOffEffectVariantT = { tlvType: TlvType.UnsignedInt } as Template<OnOffDelayedAllOffEffectVariant>;
+
+export const enum OnOffDyingLightEffectVariant {
+    "20PercentDimUpIn_0p5SecondsThenFadeToOffIn_1Second" = 0,
+}
+const OnOffDyingLightEffectVariantT = { tlvType: TlvType.UnsignedInt } as Template<OnOffDyingLightEffectVariant>;
+
+const OnOffEffectVariantT = UnsignedIntT as Template<OnOffDyingLightEffectVariant | OnOffDelayedAllOffEffectVariant>;
+
+/*
+  <bitmap name="OnOffControl" type="BITMAP8">
+    <cluster code="0x0006"/>
+    <field name="AcceptOnlyWhenOn" mask="0x01"/>
+  </bitmap>
+*/
+
+const OffWithEffectRequestT = ObjectT({
+    effectId: Field(0, OnOffEffectIdentifierT),
+    effectVariant: Field(1, OnOffEffectVariantT),
+});
+
+const OnWithTimedOffRequestT = ObjectT({
+    onOffControl: Field(0, UnsignedIntT), /* TODO: Type is a Bit map! */
+    onTime: Field(1, UnsignedIntT), /* min:0, max: 254 */
+    offWaitTime: Field(2, UnsignedIntT), /* min:0, max: 254 */
+});
+
+/**
+ * Attributes and commands for switching devices between 'On' and 'Off' states.
+ */
 export const OnOffCluster = Cluster(
     0x06,
     "On/Off",
     {
-        on: Attribute(0, BooleanT),
+        onOff: Attribute(0, BooleanT, false), /* reportable: true, scene:true */
+        globalSceneControl: OptionalAttribute(0x4000, BooleanT, true),
+        onTime: OptionalWritableAttribute(0x4001, UnsignedIntT, 0),
+        offWaitTime: OptionalWritableAttribute(0x4002, UnsignedIntT, 0),
+        startUpOnOff: OptionalWritableAttribute(0x4003, OnOffStartUpOnOffT), /* nullable: true, writeAcl: manage */
     },
     {
+        /**
+         * On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is
+         * recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime
+         * attribute SHALL be set to 0.
+         */
         off: Command(0, NoArgumentsT, 0, NoResponseT),
+        /**
+         * On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is
+         * recommended that it is used for power on or similar functions. On receipt of the On command, if the value
+         * of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.
+         */
         on: Command(1, NoArgumentsT, 1, NoResponseT),
+        /**
+         * On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise,
+         * if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value
+         * of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device
+         * SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime
+         * attribute SHALL be set to 0.
+         */
         toggle: Command(2, NoArgumentsT, 2, NoResponseT),
+        /**
+         * The OffWithEffect command allows devices to be turned off using enhanced ways of fading.
+         */
+        offWithEffect: Command(0x40, OffWithEffectRequestT, 0x40, NoResponseT), /* optional: true */
+        /**
+         * The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.
+         */
+        onWithRecallGlobalScene: Command(0x41, NoArgumentsT, 0x41, NoResponseT), /* optional: true */
+        /**
+         * The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off
+         * duration so that SHOULD the device be subsequently switched off, further OnWithTimedOff commands, received
+         * during this time, are prevented from turning the devices back on.
+         */
+        onWithTimedOff: Command(0x42, OnWithTimedOffRequestT, 0x42, NoResponseT), /* optional: true */
     },
 );
+
+/*
+Features:
+  <bitmap name="OnOffFeature" type="BITMAP32">
+    <cluster code="0x0006" />
+    <field name="Lighting" mask="0x01" />
+  </bitmap>
+
+ */

--- a/src/matter/cluster/server/OnOffServer.ts
+++ b/src/matter/cluster/server/OnOffServer.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    OnOffCluster, OnOffDelayedAllOffEffectVariant, OnOffDyingLightEffectVariant, OnOffEffectIdentifier
+} from "../OnOffCluster";
+import { ClusterServerHandlers } from "./ClusterServer";
+import { AttributeServer } from "./AttributeServer";
+
+/*
+TODO: Global Cluster fields needs to be added also here because, as discussed, based on the implementation.
+* Cluster Revision: 3 (If I get it right from the Specs)
+* FeatureMap: ??
+* AttributeList:
+  * Supported always: onOff, onTime, offWaitTime
+  * Supported if we have a scene cluster: globalSceneControl
+  * Not supported: startUpOnOff
+* AcceptedCommandList:
+  * Supported always: Off, On, Toggle, OnWithTimedOff
+  * Supported if we have a scene cluster: onWithRecallGlobalScene
+  * Supported if we have a Level cluster: OffWithEffect
+* GeneratedCommandList: empty
+* EventList: empty
+* FabricIndex: empty
+ */
+
+export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluster> = () => ({
+    // TODO In fact for the Cluster server implementation we need "initialization code" or thinks like this.
+    //      I know that it is the wrong place in the "Handlers" object, but I don't know where to put it right now
+    //      because it should be "bound to the cluster instance" and not to the "cluster type".
+    //      Yes could also be build without the subscriptions, but so the code is separated from the other implementation
+    //      parts and if used as library and the "specific device implementation" manipulates onTime or offWaitTime then
+    //      it is all handled automatically and pot. not missed.
+    constructor: ({ attributes: { onOff, onTime, offWaitTime, globalSceneControl } }) => {
+        this.onTimeTimeout: NodeJS.Timeout | null = null;
+        onTime.addMatterListener((value) => {
+            if (this.onTimeTimeout) {
+                clearTimeout(this.onTimeTimeout);
+                this.onTimeTimeout = null;
+            }
+            if (value === 0) {
+                offWaitTime.set(0);
+                onOff.set(false);
+            }
+            if (value > 0 && onOff.get()) {
+                // TODO This is the 100% accurate impelementation right now ...
+                //      maybe could be optimized without a "100ms timeout loop",
+                //      but for now should do exactly what specs say
+                this.onTimeTimeout = setTimeout(() => {
+                    this.onTimeTimeout = null;
+                    onTime.set(value - 1);
+                }, 100);
+            }
+        });
+
+        this.offWaitTimeout: NodeJS.Timeout | null = null;
+        offWaitTime.addMatterListener((value) => {
+            if (this.offWaitTimeout) {
+                clearTimeout(this.offWaitTimeout);
+                this.offWaitTimeout = null;
+            }
+            if (value > 0 && !onOff.get()) {
+                this.offWaitTimeout = setTimeout(() => {
+                    this.offWaitTimeout = null;
+                    offWaitTime.set(value - 1);
+                }, 100);
+            }
+        });
+    },
+    // TODO The trick that we used in Device.ts to access "optionalAttributes" ... how to do it here?
+    //      In fact I need to get globalSceneControl
+    on: async ({ attributes: { onOff, onTime, offWaitTime, globalSceneControl } }) => {
+        onOff.set(true);
+        globalSceneControl.set(true);
+        if (onTime.get() === 0) {
+            offWaitTime.set(0);
+        }
+    },
+    off: async ({ attributes: { onOff, onTime, offWaitTime } }) => {
+        onOff.set(false);
+        onTime.set(0);
+    },
+    toggle: async ({ attributes: { onOff, onTime, offWaitTime } }) => {
+        if (onOff.get()) {
+            onOff.set(false);
+            onTime.set(0);
+        } else {
+            onOff.set(true);
+            if (onTime.get() === 0) {
+                offWaitTime.set(0);
+            }
+        }
+    },
+    offWithEffect: async ({request: { effectId, effectVariant}, attributes: { onOff, globalSceneControl } }) => {
+        // TODO implement logic with globalSceneControl, but before:
+        // globalSceneControl controls if "the server SHALL store its settings in its global scene" ... we need to add that first
+
+        if (globalSceneControl.get()) {
+            // TODO store settings in global scene
+            globalSceneControl.set(false);
+        }
+        // The global scene is defined as the scene that is stored with group identifier 0 and scene identifier 0.
+
+        // Just example implementation for now, I would more assume because we do not support dimming that
+        // we should just set off directly without delay?
+        // TODO In my eyes we need to access the "Level cluster" on the same endpoint to control the fading/dimming and such
+        switch (effectId) {
+            case OnOffEffectIdentifier.DelayedAllOff:
+                switch (effectVariant) {
+                    case OnOffDelayedAllOffEffectVariant.FadeToOffIn_0p8Seconds:
+                        setTimeout(() => onOff.set(false), 800);
+                        break;
+                    case OnOffDelayedAllOffEffectVariant.NoFade:
+                        onOff.set(false);
+                        break;
+                    case OnOffDelayedAllOffEffectVariant["50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds"]:
+                        setTimeout(() => onOff.set(false), 12800);
+                        break;
+                }
+                break;
+            case OnOffEffectIdentifier.DyingLight:
+                switch (effectVariant) {
+                    case OnOffDyingLightEffectVariant["20PercentDimUpIn_0p5SecondsThenFadeToOffIn_1Second"]:
+                        setTimeout(() => onOff.set(false), 1500);
+                        break;
+                }
+                break;
+        }
+    },
+    onWithRecallGlobalScene: async ({ attributes: { onOff, globalSceneControl } }) => {
+        if (globalSceneControl.get()) {
+            return; // discard command
+        }
+        // TODO the Scene cluster server on the same endpoint SHALL recall its global scene, updating the OnOff
+        //      attribute accordingly. The OnOff server SHALL then set the GlobalSceneControl attribute to TRUE.
+        // if onOff set to TRUE during recalling option, set the GlobalSceneControl attribute to FALSE.
+    },
+    onWithTimedOff: async ({  request: { onOffControl, onTime, offWaitTime }, attributes: { onOff, offWaitTime: offWaitTimeAttr, onTime: onTimeAttr } }) => {
+        const onOffValue = onOff.get();
+        if (onOffControl === 1 && !onOffValue) { // TODO adjust onOffControl check when the bit map type is implemented
+            return; // discard command
+        }
+        if (offWaitTimeAttr.get() > 0 && !onOffValue) {
+            offWaitTimeAttr.set(Math.min(offWaitTime, offWaitTimeAttr.get() || 0));
+        } else {
+            onTimeAttr.set(Math.max(onTimeAttr.get(), onTime));
+            offWaitTimeAttr.set(offWaitTime);
+            onOff.set(true);
+        }
+    },
+});

--- a/src/matter/cluster/server/OnOffServer.ts
+++ b/src/matter/cluster/server/OnOffServer.ts
@@ -5,15 +5,17 @@
  */
 
 import {
-    OnOffCluster, OnOffDelayedAllOffEffectVariant, OnOffDyingLightEffectVariant, OnOffEffectIdentifier
+    OnOffCluster, DelayedAllOffEffectVariant, DyingLightEffectVariant, EffectIdentifier
 } from "../OnOffCluster";
 import { ClusterServerHandlers } from "./ClusterServer";
 import { AttributeServer } from "./AttributeServer";
+import { Time, Timer } from "../../../time/Time";
 
 /*
 TODO: Global Cluster fields needs to be added also here because, as discussed, based on the implementation.
 * Cluster Revision: 4 (If I get it right from the Specs - Application Cluster Specs 1.5.1)
-* FeatureMap: Bit 0 should be set when it is a "lighting" usecase AND Level Control cluster is supported
+* FeatureMap:
+  * Bit 0 should be set when it is a "lighting" usecase AND Level Control cluster is supported
 * AttributeList:
   * Supported always: onOff, onTime, offWaitTime
   * Supported if we have a scene cluster: globalSceneControl
@@ -33,59 +35,71 @@ TODO: If the Scenes server cluster is implemented on the same endpoint, the foll
       * OnOff
  */
 
-export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluster> = () => ({
+class OnOffClusterHandler2 implements ClusterServerHandlers<typeof OnOffCluster> {
+    private onTimeTimeout: Timer | undefined;
+    private offWaitTimeout: Timer | undefined;
+
     // TODO In fact for the Cluster server implementation we need "initialization code" or thinks like this.
     //      I know that it is the wrong place in the "Handlers" object, but I don't know where to put it right now
     //      because it should be "bound to the cluster instance" and not to the "cluster type".
     //      Yes could also be build without the subscriptions, but so the code is separated from the other implementation
     //      parts and if used as library and the "specific device implementation" manipulates onTime or offWaitTime then
     //      it is all handled automatically and pot. not missed.
-    constructor: ({ attributes: { onOff, onTime, offWaitTime, globalSceneControl } }) => {
-        this.onTimeTimeout: NodeJS.Timeout | null = null;
-        onTime.addMatterListener((value) => {
-            if (this.onTimeTimeout) {
-                clearTimeout(this.onTimeTimeout);
-                this.onTimeTimeout = null;
-            }
+
+    constructor() {
+        // I know that "this attributes" is wrong ... :-)
+        this.attributes.onTime.addMatterListener((value: number | null) => {
+            this.onTimeTimeout?.stop();
             if (value === 0) {
-                offWaitTime.set(0);
-                onOff.set(false);
+                this.attributes.offWaitTime.set(0);
+                this.attributes.onOff.set(false);
             }
-            if (value > 0 && onOff.get()) {
+            if (value === null || this.attributes.offWaitTime.get() === null) {
+                return; // do nothing
+            }
+            if (value > 0 && this.attributes.onOff.get()) {
                 // TODO This is the 100% accurate impelementation right now ...
                 //      maybe could be optimized without a "100ms timeout loop",
                 //      but for now should do exactly what specs say
-                this.onTimeTimeout = setTimeout(() => {
-                    this.onTimeTimeout = null;
-                    onTime.set(value - 1);
-                }, 100);
+                this.onTimeTimeout = Time.getTimer(100, () =>
+                    this.attributes.onTime.set(value - 1)).start();
             }
         });
 
-        this.offWaitTimeout: NodeJS.Timeout | null = null;
-        offWaitTime.addMatterListener((value) => {
-            if (this.offWaitTimeout) {
-                clearTimeout(this.offWaitTimeout);
-                this.offWaitTimeout = null;
+        this.attributes.offWaitTime.addMatterListener((value: number | null) => {
+            this.offWaitTimeout?.stop();
+            if (value === null || this.attributes.onTime.get() === null) {
+                return; // do nothing
             }
-            if (value > 0 && !onOff.get()) {
-                this.offWaitTimeout = setTimeout(() => {
-                    this.offWaitTimeout = null;
-                    offWaitTime.set(value - 1);
-                }, 100);
+            if (value > 0 && !this.attributes.onOff.get()) {
+                this.offWaitTimeout = Time.getTimer(100, () =>
+                    this.attributes.offWaitTime.set(value - 1)).start();
             }
         });
-    },
+    }
+
+}
+
+// TODO
+// We might need to differentiate if an attribute is set internally otr "by a write command from externally":
+// From Specs: onTime: This attribute can be written at any time, but writing a value only has effect when in the
+//             ‘Timed On’ state. See OnWithTimedOff Command for more details.
+// From Specs: offWaitTime: This attribute can be written at any time, but writing a value only has an effect when
+//             in the ‘Timed On’ state followed by a transition to the ‘Delayed Off' state, or in the ‘Delayed Off’
+//             state.
+
+export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluster> = () => ({
     // TODO The trick that we used in Device.ts to access "optionalAttributes" ... how to do it here?
     //      In fact I need to get globalSceneControl
-    on: async ({ attributes: { onOff, onTime, offWaitTime, globalSceneControl } }) => {
+    on: async ({ attributes: { onOff, onTime, offWaitTime/*, globalSceneControl*/ } }) => {
         onOff.set(true);
-        globalSceneControl.set(true);
+        // TODO When implementing Scenes cluster
+        //globalSceneControl.set(true);
         if (onTime.get() === 0) {
             offWaitTime.set(0);
         }
     },
-    off: async ({ attributes: { onOff, onTime, offWaitTime } }) => {
+    off: async ({ attributes: { onOff, onTime} }) => {
         onOff.set(false);
         onTime.set(0);
     },
@@ -100,46 +114,47 @@ export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluste
             }
         }
     },
-    offWithEffect: async ({request: { effectId, effectVariant}, attributes: { onOff, globalSceneControl } }) => {
+    // TODO document out until LevelControl and SceneControl is existing
+    offWithEffect: async ({request: { effectIdentifier, effectVariant}, attributes: { onOff/*, globalSceneControl*/ } }) => {
         // TODO implement logic with globalSceneControl, but before:
         // globalSceneControl controls if "the server SHALL store its settings in its global scene" ... we need to add that first
-
-        if (globalSceneControl.get()) {
-            // TODO store settings in global scene
-            globalSceneControl.set(false);
-        }
+        //if (globalSceneControl.get()) {
+        //    // TODO store settings in global scene
+        //    globalSceneControl.set(false);
+        //}
         // The global scene is defined as the scene that is stored with group identifier 0 and scene identifier 0.
 
         // Just example implementation for now, I would more assume because we do not support dimming that
         // we should just set off directly without delay?
         // TODO In my eyes we need to access the "Level cluster" on the same endpoint to control the fading/dimming and such
-        switch (effectId) {
-            case OnOffEffectIdentifier.DelayedAllOff:
+        switch (effectIdentifier) {
+            case EffectIdentifier.DelayedAllOff:
                 switch (effectVariant) {
-                    case OnOffDelayedAllOffEffectVariant.FadeToOffIn_0p8Seconds:
+                    case DelayedAllOffEffectVariant.Fade:
                         setTimeout(() => onOff.set(false), 800);
                         break;
-                    case OnOffDelayedAllOffEffectVariant.NoFade:
+                    case DelayedAllOffEffectVariant.NoFade:
                         onOff.set(false);
                         break;
-                    case OnOffDelayedAllOffEffectVariant["50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds"]:
+                    case DelayedAllOffEffectVariant["DimDownThenFade"]:
                         setTimeout(() => onOff.set(false), 12800);
                         break;
                 }
                 break;
-            case OnOffEffectIdentifier.DyingLight:
+            case EffectIdentifier.DyingLight:
                 switch (effectVariant) {
-                    case OnOffDyingLightEffectVariant["20PercentDimUpIn_0p5SecondsThenFadeToOffIn_1Second"]:
+                    case DyingLightEffectVariant["DimUpThenFade"]:
                         setTimeout(() => onOff.set(false), 1500);
                         break;
                 }
                 break;
         }
     },
-    onWithRecallGlobalScene: async ({ attributes: { onOff, globalSceneControl } }) => {
-        if (globalSceneControl.get()) {
-            return; // discard command
-        }
+    onWithRecallGlobalScene: async ({ attributes: { onOff/*, globalSceneControl*/ } }) => {
+        // TODO implement logic with globalSceneControl, but before:
+        //if (globalSceneControl.get()) {
+        //    return; // discard command
+        //}
         // TODO the Scene cluster server on the same endpoint SHALL recall its global scene, updating the OnOff
         //      attribute accordingly. The OnOff server SHALL then set the GlobalSceneControl attribute to TRUE.
         // if onOff set to TRUE during recalling option, set the GlobalSceneControl attribute to FALSE.
@@ -149,8 +164,8 @@ export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluste
         if (onOffControl === 1 && !onOffValue) { // TODO adjust onOffControl check when the bit map type is implemented
             return; // discard command
         }
-        if (offWaitTimeAttr.get() > 0 && !onOffValue) {
-            offWaitTimeAttr.set(Math.min(offWaitTime, offWaitTimeAttr.get() || 0));
+        if (!onOffValue && offWaitTimeAttr.get() > 0) {
+            offWaitTimeAttr.set(Math.min(offWaitTime, offWaitTimeAttr.get()));
         } else {
             onTimeAttr.set(Math.max(onTimeAttr.get(), onTime));
             offWaitTimeAttr.set(offWaitTime);

--- a/src/matter/cluster/server/OnOffServer.ts
+++ b/src/matter/cluster/server/OnOffServer.ts
@@ -12,8 +12,8 @@ import { AttributeServer } from "./AttributeServer";
 
 /*
 TODO: Global Cluster fields needs to be added also here because, as discussed, based on the implementation.
-* Cluster Revision: 3 (If I get it right from the Specs)
-* FeatureMap: ??
+* Cluster Revision: 4 (If I get it right from the Specs - Application Cluster Specs 1.5.1)
+* FeatureMap: Bit 0 should be set when it is a "lighting" usecase AND Level Control cluster is supported
 * AttributeList:
   * Supported always: onOff, onTime, offWaitTime
   * Supported if we have a scene cluster: globalSceneControl
@@ -25,6 +25,12 @@ TODO: Global Cluster fields needs to be added also here because, as discussed, b
 * GeneratedCommandList: empty
 * EventList: empty
 * FabricIndex: empty
+ */
+
+/*
+TODO: If the Scenes server cluster is implemented on the same endpoint, the following extension field SHALL
+      be added to the Scene Table:
+      * OnOff
  */
 
 export const OnOffClusterHandler: () => ClusterServerHandlers<typeof OnOffCluster> = () => ({


### PR DESCRIPTION
As discussed here a "minimal/pseudo" implementation of OnOff Cluster that defines all attribues, commands and also shows a bit f the "topics" to discuss and decide.

thats why it is a lot of Todos and comments inside and yes it will not build right now ;-) But the main goal for now would be to show you better what I mean sop that we discuss "on topic" and not too theoretically. I hope it helps.