### PR TITLE
Bump version to 0.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "node-matter",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-matter",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4"
       },
       "bin": {
-        "matter": "build/Main.js",
+        "matter": "build/Device.js",
         "matter-controller": "build/Controller.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-matter",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Matter protocol for node.js",
   "keywords": [
     "iot",


### PR DESCRIPTION
I had to make an emergency release of 0.0.10 since 0.0.9 was broken because of a misconfiguration in package.json