### PR TITLE
Fix merge and make mandatory

### DIFF
--- a/src/util/Type.ts
+++ b/src/util/Type.ts
@@ -5,4 +5,4 @@
  */
 
 /** Merges two types into one */
-export type Merge<A, B, AB = A & B> = { [K in keyof AB]: AB[K] };
+export type Merge<A, B> = A & B extends infer AB ? { [K in keyof AB]: AB[K] } : never;


### PR DESCRIPTION
Merge was using an variable AB that could overridden when used
Make mandatory was erasing the writable type