### PR TITLE
Add strong type support for VendorId and NodeId

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -30,6 +30,7 @@ import { Time } from "./time/Time";
 import { TimeNode } from "./time/TimeNode";
 import packageJson from "../package.json";
 import { Logger } from "./log/Logger";
+import { VendorId } from "./matter/common/VendorId";
 
 // From Chip-Test-DAC-FFF1-8000-0007-Key.der
 const DevicePrivateKey = Buffer.from("727F1005CBA47ED7822A9D930943621617CFD3B79D9AF528B801ECF9F1992204", "hex");
@@ -55,7 +56,7 @@ class Device {
         const deviceName = "Matter test device";
         const deviceType = 257 /* Dimmable bulb */;
         const vendorName = "node-matter";
-        const vendorId = 0xFFF1;
+        const vendorId = VendorId(0xFFF1);
         const productName = "Matter test device";
         const productId = 0X8001;
         const discriminator = 3840;

--- a/src/codec/MessageCodec.ts
+++ b/src/codec/MessageCodec.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeId, nodeIdToBigint } from "../matter/common/NodeId";
 import { LEBufferReader } from "../util/LEBufferReader";
 import { LEBufferWriter } from "../util/LEBufferWriter";
 
@@ -11,8 +12,8 @@ export interface PacketHeader {
     sessionId: number,
     sessionType: SessionType,
     messageId: number,
-    sourceNodeId?: bigint,
-    destNodeId?: bigint,
+    sourceNodeId?: NodeId,
+    destNodeId?: NodeId,
     destGroupId?: number,
 }
 
@@ -113,8 +114,8 @@ export class MessageCodec {
         const sessionId = reader.readUInt16();
         const securityFlags = reader.readUInt8();
         const messageId = reader.readUInt32();
-        const sourceNodeId = hasSourceNodeId ? reader.readUInt64() : undefined;
-        const destNodeId = hasDestNodeId ? reader.readUInt64() : undefined;
+        const sourceNodeId = hasSourceNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destNodeId = hasDestNodeId ? NodeId(reader.readUInt64()) : undefined;
         const destGroupId = hasDestGroupId ? reader.readUInt16() : undefined;
 
         const sessionType = securityFlags & 0b00000011;
@@ -153,8 +154,8 @@ export class MessageCodec {
         writer.writeUInt16(sessionId);
         writer.writeUInt8(securityFlags);
         writer.writeUInt32(messageCounter);
-        if (sourceNodeId !== undefined) writer.writeUInt64(sourceNodeId);
-        if (destNodeId !== undefined) writer.writeUInt64(destNodeId);
+        if (sourceNodeId !== undefined) writer.writeUInt64(nodeIdToBigint(sourceNodeId));
+        if (destNodeId !== undefined) writer.writeUInt64(nodeIdToBigint(destNodeId));
         if (destGroupId !== undefined) writer.writeUInt32(destGroupId);
         return writer.toBuffer();
     }

--- a/src/codec/TlvObjectCodec.ts
+++ b/src/codec/TlvObjectCodec.ts
@@ -32,6 +32,7 @@ export const AnyT:Template<any> = { };
 export const ArrayT = <T,>(itemTemplate: Template<T>) => ({ tlvType: TlvType.Array, itemTemplate } as Template<T[]>);
 export const ObjectT = <F extends FieldTemplates>(fieldTemplates: F, tlvType: TlvType = TlvType.Structure) => ({ tlvType, fieldTemplates } as Template<TypeFromFieldTemplates<F>>);
 export const EnumT = <T,>() => UnsignedIntT as Template<T>;
+export const Typed = <T,>(template: Template<any>) => template as Template<T>;
 export const Field = <T,>(id: number, type: Template<T>):Field<T> =>  ({...type, tag: TlvTag.contextual(id), optional: false});
 export const OptionalField = <T,>(id: number, type: Template<T>):OptionalField<T> =>  ({...Field(id, type), optional: true});
 

--- a/src/codec/TlvObjectCodec.ts
+++ b/src/codec/TlvObjectCodec.ts
@@ -31,6 +31,7 @@ export const UnsignedLongT:Template<bigint> = { tlvType: TlvType.UnsignedInt, re
 export const AnyT:Template<any> = { };
 export const ArrayT = <T,>(itemTemplate: Template<T>) => ({ tlvType: TlvType.Array, itemTemplate } as Template<T[]>);
 export const ObjectT = <F extends FieldTemplates>(fieldTemplates: F, tlvType: TlvType = TlvType.Structure) => ({ tlvType, fieldTemplates } as Template<TypeFromFieldTemplates<F>>);
+export const EnumT = <T,>() => UnsignedIntT as Template<T>;
 export const Field = <T,>(id: number, type: Template<T>):Field<T> =>  ({...type, tag: TlvTag.contextual(id), optional: false});
 export const OptionalField = <T,>(id: number, type: Template<T>):OptionalField<T> =>  ({...Field(id, type), optional: true});
 

--- a/src/matter/MatterController.ts
+++ b/src/matter/MatterController.ts
@@ -23,12 +23,14 @@ import { requireMinNodeVersion } from "../util/Node";
 import { ChannelManager } from "./common/ChannelManager";
 import { Logger } from "../log/Logger";
 import { Time } from "../time/Time";
+import { NodeId } from "./common/NodeId";
+import { VendorId } from "./common/VendorId";
 
 requireMinNodeVersion(16);
 
 const FABRIC_ID = BigInt(1);
-const CONTROLLER_NODE_ID = BigInt(0);
-const ADMIN_VENDOR_ID = 752;
+const CONTROLLER_NODE_ID = NodeId(BigInt(0));
+const ADMIN_VENDOR_ID = VendorId(752);
 const logger = Logger.get("MatterController");
 
 export class MatterController {
@@ -93,7 +95,7 @@ export class MatterController {
         const operationalPublicKey = CertificateManager.getPublicKeyFromCsr(certSigningRequest);
 
         await operationalCredentialsClusterClient.addRootCert({ certificate: this.certificateManager.getRootCert() });
-        const peerNodeId = BigInt(1);
+        const peerNodeId = NodeId(BigInt(1));
         const peerOperationalCert = this.certificateManager.generateNoc(operationalPublicKey, FABRIC_ID, peerNodeId);
         await operationalCredentialsClusterClient.addOperationalCert({
             operationalCert: peerOperationalCert,
@@ -120,7 +122,7 @@ export class MatterController {
         this.ensureSuccess(await generalCommissioningClusterClient.commissioningComplete({}));
     }
 
-    async connect(nodeId: bigint) {
+    async connect(nodeId: NodeId) {
         return new InteractionClient(this.exchangeManager, this.channelManager.getChannel(this.fabric, nodeId));
     }
 
@@ -133,7 +135,7 @@ export class MatterController {
         return this.sessionManager.getNextAvailableSessionId();
     }
 
-    createSecureSession(sessionId: number, fabric: Fabric | undefined,  peerNodeId: bigint, peerSessionId: number, sharedSecret: Buffer, salt: Buffer, isInitiator: boolean, isResumption: boolean, idleRetransTimeoutMs?: number, activeRetransTimeoutMs?: number) {
+    createSecureSession(sessionId: number, fabric: Fabric | undefined,  peerNodeId: NodeId, peerSessionId: number, sharedSecret: Buffer, salt: Buffer, isInitiator: boolean, isResumption: boolean, idleRetransTimeoutMs?: number, activeRetransTimeoutMs?: number) {
         return this.sessionManager.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, salt, isInitiator, isResumption, idleRetransTimeoutMs, activeRetransTimeoutMs);
     }
 
@@ -141,7 +143,7 @@ export class MatterController {
         return this.sessionManager.findResumptionRecordById(resumptionId);
     }
 
-    findResumptionRecordByNodeId(nodeId: bigint) {
+    findResumptionRecordByNodeId(nodeId: NodeId) {
         return this.sessionManager.findResumptionRecordByNodeId(nodeId);
     }
 
@@ -189,7 +191,7 @@ class RootCertificateManager {
         return TlvObjectCodec.encode({ ...unsignedCertificate, signature }, RootCertificateT);
     }
 
-    generateNoc(publicKey: Buffer, fabricId: bigint, nodeId: bigint): Buffer {
+    generateNoc(publicKey: Buffer, fabricId: bigint, nodeId: NodeId): Buffer {
         const now = Time.get().now();
         const certId = this.nextCertificateId++;
         const unsignedCertificate = {

--- a/src/matter/MatterDevice.ts
+++ b/src/matter/MatterDevice.ts
@@ -16,6 +16,8 @@ import { ExchangeManager } from "./common/ExchangeManager";
 import { requireMinNodeVersion } from "../util/Node";
 import { Scanner } from "./common/Scanner";
 import { ChannelManager } from "./common/ChannelManager";
+import { VendorId } from "./common/VendorId";
+import { NodeId } from "./common/NodeId";
 
 requireMinNodeVersion(16);
 
@@ -31,7 +33,7 @@ export class MatterDevice {
     constructor(
         private readonly deviceName: string,
         private readonly deviceType: number,
-        private readonly vendorId: number,
+        private readonly vendorId: VendorId,
         private readonly productId: number,
         private readonly discriminator: number,
     ) {}
@@ -66,7 +68,7 @@ export class MatterDevice {
         return this.sessionManager.getNextAvailableSessionId();
     }
 
-    createSecureSession(sessionId: number, fabric: Fabric | undefined, peerNodeId: bigint, peerSessionId: number, sharedSecret: Buffer, salt: Buffer, isInitiator: boolean, isResumption: boolean, idleRetransTimeoutMs?: number, activeRetransTimeoutMs?: number) {
+    createSecureSession(sessionId: number, fabric: Fabric | undefined, peerNodeId: NodeId, peerSessionId: number, sharedSecret: Buffer, salt: Buffer, isInitiator: boolean, isResumption: boolean, idleRetransTimeoutMs?: number, activeRetransTimeoutMs?: number) {
         return this.sessionManager.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, salt, isInitiator, isResumption, idleRetransTimeoutMs, activeRetransTimeoutMs);
     }
 
@@ -82,7 +84,7 @@ export class MatterDevice {
         });
     }
 
-    initiateExchange(fabric: Fabric, nodeId: bigint, protocolId: number) {
+    initiateExchange(fabric: Fabric, nodeId: NodeId, protocolId: number) {
         return this.exchangeManager.initiateExchange(fabric, nodeId, protocolId);
     }
 
@@ -106,7 +108,7 @@ export class MatterDevice {
         return this.fabricManager.completeCommission();
     }
 
-    async findDevice(fabric: Fabric, nodeId: bigint): Promise<undefined | {session: Session<MatterDevice>, channel: Channel<Buffer>}> {
+    async findDevice(fabric: Fabric, nodeId: NodeId): Promise<undefined | {session: Session<MatterDevice>, channel: Channel<Buffer>}> {
         // TODO: return the first not undefined answer or undefined
         const matterServer = await this.scanners[0].findDevice(fabric, nodeId);
         if (matterServer === undefined) return undefined;

--- a/src/matter/certificate/CertificateManager.ts
+++ b/src/matter/certificate/CertificateManager.ts
@@ -6,8 +6,9 @@
 
 import { AuthorityKeyIdentifier_X509, BasicConstraints_X509, BitBuffer, BYTES_KEY, ContextTagged, DerCodec, DerObject, EcdsaWithSHA256_X962, ELEMENTS_KEY, ExtendedKeyUsage_X509, KeyUsage_Signature_ContentCommited_X509, KeyUsage_Signature_X509, OBJECT_ID_KEY, OrganisationName_X520, PublicKeyEcPrime256v1_X962, SubjectKeyIdentifier_X509 } from "../../codec/DerCodec";
 import { TlvType } from "../../codec/TlvCodec";
-import { ArrayT, BooleanT, ByteStringT, Field, JsType, ObjectT, OptionalField, UnsignedIntT, UnsignedLongT } from "../../codec/TlvObjectCodec";
+import { ArrayT, BooleanT, ByteStringT, Field, JsType, ObjectT, OptionalField, Typed, UnsignedIntT, UnsignedLongT } from "../../codec/TlvObjectCodec";
 import { Crypto, KeyPair } from "../../crypto/Crypto";
+import { NodeId, nodeIdToBigint } from "../common/NodeId";
 
 const YEAR_S = 365 * 24 * 60 * 60;
 const EPOCH_OFFSET_S = 10957 * 24 * 60 * 60;
@@ -25,7 +26,7 @@ function intTo16Chars(value: bigint | number) {
 }
 
 export const FabricId_Matter = (id: bigint) => [ DerObject("2b0601040182a27c0105", {value: intTo16Chars(id)}) ];
-export const NodeId_Matter = (id: bigint) => [ DerObject("2b0601040182a27c0101", {value: intTo16Chars(id)}) ];
+export const NodeId_Matter = (nodeId: NodeId) => [ DerObject("2b0601040182a27c0101", {value: intTo16Chars(nodeIdToBigint(nodeId))}) ];
 export const RcacId_Matter = (id: number) => [ DerObject("2b0601040182a27c0104", {value: intTo16Chars(id)}) ];
 
 export const RootCertificateT = ObjectT({
@@ -66,7 +67,7 @@ export const OperationalCertificateT = ObjectT({
     notAfter: Field(5, UnsignedIntT),
     subject: Field(6, ObjectT({
         fabricId: Field(21, UnsignedLongT),
-        nodeId: Field(17, UnsignedLongT),
+        nodeId: Field(17, Typed<NodeId>(UnsignedLongT)),
     }, TlvType.List)),
     publicKeyAlgorithm: Field(7, UnsignedIntT),
     ellipticCurveIdentifier: Field(8, UnsignedIntT),

--- a/src/matter/cluster/BasicInformationCluster.ts
+++ b/src/matter/cluster/BasicInformationCluster.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BooleanT, StringT, UnsignedIntT, ObjectT, Field } from "../../codec/TlvObjectCodec";
+import { BooleanT, StringT, UnsignedIntT, ObjectT, Field, Typed } from "../../codec/TlvObjectCodec";
+import { VendorId } from "../common/VendorId";
 import { Attribute, Cluster, OptionalAttribute, OptionalWritableAttribute, WritableAttribute } from "./Cluster";
 
 const CapabilityMinimaT = ObjectT({
@@ -23,7 +24,7 @@ export const BasicInformationCluster = Cluster(
     {
             dataModelRevision: Attribute(0, UnsignedIntT),
             vendorName: Attribute(1, StringT), /* maxLength: 32 */
-            vendorId: Attribute(2, UnsignedIntT), /* type: vendor-id */
+            vendorId: Attribute(2, Typed<VendorId>(UnsignedIntT)), /* type: vendor-id */
             productName: Attribute(3, StringT), /* maxLength: 32 */
             productId: Attribute(4, UnsignedIntT),
             nodeLabel: WritableAttribute(5, StringT, ""), /* maxLength: 32, writeAcl: manage */

--- a/src/matter/cluster/GeneralCommissioningCluster.ts
+++ b/src/matter/cluster/GeneralCommissioningCluster.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Field, JsType, ObjectT, StringT, Template, UnsignedIntT, UnsignedLongT, BooleanT } from "../../codec/TlvObjectCodec";
+import { Field, JsType, ObjectT, StringT, UnsignedIntT, UnsignedLongT, BooleanT, EnumT } from "../../codec/TlvObjectCodec";
 import { TlvType } from "../../codec/TlvCodec";
 import { Attribute, Cluster, Command, NoArgumentsT, OptionalAttribute, WritableAttribute } from "./Cluster";
 
@@ -13,7 +13,6 @@ export const enum RegulatoryLocationType {
     Outdoor = 1,
     IndoorOutdoor = 2,
 }
-const RegulatoryLocationTypeT = { tlvType: TlvType.UnsignedInt } as Template<RegulatoryLocationType>;
 
 export const enum CommissioningError {
     Ok = 0,
@@ -22,7 +21,6 @@ export const enum CommissioningError {
     NoFailSafe = 3,
     BusyWithOtherAdmin = 4,
 }
-const CommissioningErrorT = { tlvType: TlvType.UnsignedInt } as Template<CommissioningError>;
 
 const BasicCommissioningInfoT = ObjectT({
     failSafeExpiryLengthSeconds: Field(0, UnsignedIntT),
@@ -30,7 +28,7 @@ const BasicCommissioningInfoT = ObjectT({
 });
 
 const CommissioningSuccessFailureResponseT = ObjectT({
-    errorCode: Field(0, CommissioningErrorT),
+    errorCode: Field(0, EnumT<CommissioningError>()),
     debugText: Field(1, StringT),
 });
 export type CommissioningSuccessFailureResponse = JsType<typeof CommissioningSuccessFailureResponseT>;
@@ -41,7 +39,7 @@ const ArmFailSafeRequestT = ObjectT({
 });
 
 const SetRegulatoryConfigRequestT = ObjectT({
-    newRegulatoryConfig: Field(0, RegulatoryLocationTypeT),
+    newRegulatoryConfig: Field(0, EnumT<RegulatoryLocationType>()),
     countryCode: Field(1, StringT), /* length: 2 */
     breadcrumbStep: Field(2, UnsignedLongT),
 });
@@ -55,8 +53,8 @@ export const GeneralCommissioningCluster = Cluster(
     {
         breadcrumb: WritableAttribute(0, UnsignedLongT, BigInt(0)), /* writeAcl: administer */
         commissioningInfo: Attribute(1, BasicCommissioningInfoT),
-        regulatoryConfig: Attribute(2, RegulatoryLocationTypeT), /* default: value of locationCapability */
-        locationCapability: Attribute(3, RegulatoryLocationTypeT, RegulatoryLocationType.IndoorOutdoor),
+        regulatoryConfig: Attribute(2, EnumT<RegulatoryLocationType>()), /* default: value of locationCapability */
+        locationCapability: Attribute(3, EnumT<RegulatoryLocationType>(), RegulatoryLocationType.IndoorOutdoor),
         supportsConcurrentConnections: Attribute(4, BooleanT, true),
     },
     {

--- a/src/matter/cluster/GeneralCommissioningCluster.ts
+++ b/src/matter/cluster/GeneralCommissioningCluster.ts
@@ -5,8 +5,7 @@
  */
 
 import { Field, JsType, ObjectT, StringT, UnsignedIntT, UnsignedLongT, BooleanT, EnumT } from "../../codec/TlvObjectCodec";
-import { TlvType } from "../../codec/TlvCodec";
-import { Attribute, Cluster, Command, NoArgumentsT, OptionalAttribute, WritableAttribute } from "./Cluster";
+import { Attribute, Cluster, Command, NoArgumentsT, WritableAttribute } from "./Cluster";
 
 export const enum RegulatoryLocationType {
     Indoor = 0,

--- a/src/matter/cluster/OperationalCredentialsCluster.ts
+++ b/src/matter/cluster/OperationalCredentialsCluster.ts
@@ -5,14 +5,16 @@
  */
 
 import { Attribute, Cluster, Command, NoResponseT } from "./Cluster";
-import { TlvType } from "../../codec/TlvCodec";
-import { ByteStringT, Field, ObjectT, OptionalField, UnsignedIntT, UnsignedLongT, StringT, ArrayT, BooleanT, EnumT } from "../../codec/TlvObjectCodec";
+import { ByteStringT, Field, ObjectT, OptionalField, UnsignedIntT, UnsignedLongT, StringT, ArrayT, BooleanT, EnumT, Typed } from "../../codec/TlvObjectCodec";
+import { VendorId } from "../common/VendorId";
+import { NodeId } from "../common/NodeId";
+import { SubjectId } from "../common/SubjectId";
 
 const FabricDescriptorT = ObjectT({
     rootPublicKey: Field(1, ByteStringT), /* length: 65 */
-    vendorId: Field(2, UnsignedIntT), /* type: vendor-id */
+    vendorId: Field(2, Typed<VendorId>(UnsignedIntT)),
     fabricID: Field(3, UnsignedIntT), /* type: fabric-id */
-    nodeID: Field(4, UnsignedIntT), /* type: node-id */
+    nodeID: Field(4, Typed<NodeId>(UnsignedIntT)),
     label: Field(5, StringT), /* maxLength: 32, default: "" */
 });
 
@@ -57,8 +59,8 @@ export const AddNocRequestT = ObjectT({
     operationalCert: Field(0, ByteStringT), /* maxLength: 400 */
     intermediateCaCert: OptionalField(1, ByteStringT), /* maxLength: 400 */
     identityProtectionKey: Field(2, ByteStringT), /* length: 16 */
-    caseAdminNode: Field(3, UnsignedLongT), /* type: subject-id */
-    adminVendorId: Field(4, UnsignedIntT), /* type: vendor-id */
+    caseAdminNode: Field(3, Typed<SubjectId>(UnsignedLongT)),
+    adminVendorId: Field(4, Typed<VendorId>(UnsignedIntT)),
 });
 
 export const UpdateNocRequestT = ObjectT({

--- a/src/matter/cluster/OperationalCredentialsCluster.ts
+++ b/src/matter/cluster/OperationalCredentialsCluster.ts
@@ -6,7 +6,7 @@
 
 import { Attribute, Cluster, Command, NoResponseT } from "./Cluster";
 import { TlvType } from "../../codec/TlvCodec";
-import { ByteStringT, Field, ObjectT, OptionalField, Template, UnsignedIntT, UnsignedLongT, StringT, ArrayT, BooleanT } from "../../codec/TlvObjectCodec";
+import { ByteStringT, Field, ObjectT, OptionalField, UnsignedIntT, UnsignedLongT, StringT, ArrayT, BooleanT, EnumT } from "../../codec/TlvObjectCodec";
 
 const FabricDescriptorT = ObjectT({
     rootPublicKey: Field(1, ByteStringT), /* length: 65 */
@@ -25,7 +25,6 @@ export const enum CertificateType {
     DeviceAttestation = 1,
     ProductAttestationIntermediate = 2,
 }
-export const CertificateTypeT = { tlvType: TlvType.UnsignedInt } as Template<CertificateType>;
 
 export const AttestationRequestT = ObjectT({
     attestationNonce: Field(0, ByteStringT), /* length: 32 */
@@ -47,7 +46,7 @@ export const CertSigningRequestResponseT = ObjectT({
 });
 
 export const CertChainRequestT = ObjectT({
-    type: Field(0, CertificateTypeT),
+    type: Field(0, EnumT<CertificateType>()),
 });
 
 export const CertChainResponseT = ObjectT({
@@ -83,10 +82,9 @@ export const enum OperationalCertStatus {
     LabelConflict = 0x0a,
     InvalidFabricIndex = 0x0b,
 }
-const OperationalCertStatusT = { tlvType: TlvType.UnsignedInt } as Template<OperationalCertStatus>;
 
 export const OperationalCertificateStatusResponseT = ObjectT({
-    status: Field(0, OperationalCertStatusT),
+    status: Field(0, EnumT<OperationalCertStatus>()),
     fabricIndex: OptionalField(1, UnsignedIntT), /* min: 1, max: 254, type: fabric_idx */
     debugText: OptionalField(2, StringT), /* maxLength: 128 */
 });

--- a/src/matter/common/Broadcaster.ts
+++ b/src/matter/common/Broadcaster.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeId } from "./NodeId";
+import { VendorId } from "./VendorId";
+
 export interface Broadcaster {
-    setCommissionMode(deviceName: string, deviceType: number, vendorId: number, productId: number, discriminator: number): void;
-    setFabric(operationalId: Buffer, nodeId: bigint): void;
+    setCommissionMode(deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number): void;
+    setFabric(operationalId: Buffer, nodeId: NodeId): void;
     announce(): Promise<void>;
     close(): void;
 }

--- a/src/matter/common/ChannelManager.ts
+++ b/src/matter/common/ChannelManager.ts
@@ -9,15 +9,16 @@ import { Fabric } from "../fabric/Fabric";
 import { SecureSession } from "../session/SecureSession";
 import { Session } from "../session/Session";
 import { MessageChannel } from "./ExchangeManager";
+import { NodeId } from "./NodeId";
 
 export class ChannelManager {
     private readonly channels = new Map<string, MessageChannel<any>>();
 
-    setChannel(fabric: Fabric, nodeId: bigint, channel: MessageChannel<any>) {
+    setChannel(fabric: Fabric, nodeId: NodeId, channel: MessageChannel<any>) {
         this.channels.set(`${fabric.id}/${nodeId}`, channel);
     }
 
-    getChannel(fabric: Fabric, nodeId: bigint) {
+    getChannel(fabric: Fabric, nodeId: NodeId) {
         const result = this.channels.get(`${fabric.id}/${nodeId}`);
         if (result === undefined) throw new Error(`Can't find find a channel to node ${nodeId}`);
         return result;

--- a/src/matter/common/ExchangeManager.ts
+++ b/src/matter/common/ExchangeManager.ts
@@ -15,6 +15,7 @@ import { ProtocolHandler } from "./ProtocolHandler";
 import { ChannelManager } from "./ChannelManager";
 import { Fabric } from "../fabric/Fabric";
 import { Logger } from "../../log/Logger";
+import { NodeId } from "./NodeId";
 
 const logger = Logger.get("MessageChannel");
 
@@ -56,7 +57,7 @@ export class ExchangeManager<ContextT> {
         this.protocols.set(protocol.getId(), protocol);
     }
 
-    initiateExchange(fabric: Fabric, nodeId: bigint, protocolId: number) {
+    initiateExchange(fabric: Fabric, nodeId: NodeId, protocolId: number) {
         return this.initiateExchangeWithChannel(this.channelManager.getChannel(fabric, nodeId), protocolId);
     }
 

--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -12,6 +12,7 @@ import { MessageChannel, MessageCounter } from "./ExchangeManager";
 import { getPromiseResolver } from "../../util/Promises";
 import { Time, Timer } from "../../time/Time";
 import { Logger } from "../../log/Logger";
+import { NodeId, nodeIdToBigint } from "./NodeId";
 
 const logger = Logger.get("MessageExchange");
 
@@ -76,8 +77,8 @@ export class MessageExchange<ContextT> {
         private readonly messageCounter: MessageCounter,
         private readonly isInitiator: boolean,
         private readonly peerSessionId: number,
-        private readonly nodeId: bigint | undefined,
-        private readonly peerNodeId: bigint | undefined,
+        private readonly nodeId: NodeId | undefined,
+        private readonly peerNodeId: NodeId | undefined,
         private readonly exchangeId: number,
         private readonly protocolId: number,
         private readonly closeCallback: () => void,

--- a/src/matter/common/NodeId.ts
+++ b/src/matter/common/NodeId.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A Node Identifier (Node ID) is a 64-bit number that uniquely identifies an individual Node or a
+ * group of Nodes on a Fabric.
+ * 
+ * @see [Matter Specification R1.0], section 2.5.5
+ */
+export type NodeId = { nodeId: true /* Hack to force strong type checking at compile time */ };
+export const NodeId = (id: bigint) => id as unknown as NodeId;
+
+/** Explicitly convert a NodeId to a bigint */
+export const nodeIdToBigint = (nodeId: NodeId) => nodeId as unknown as bigint;

--- a/src/matter/common/Scanner.ts
+++ b/src/matter/common/Scanner.ts
@@ -5,6 +5,7 @@
  */
 
 import { Fabric } from "../fabric/Fabric";
+import { NodeId } from "./NodeId";
 
 export type MatterServer = {
     ip: string,
@@ -12,6 +13,6 @@ export type MatterServer = {
 };
 
 export interface Scanner {
-    findDevice(fabric: Fabric, nodeId: bigint): Promise<MatterServer | undefined>;
+    findDevice(fabric: Fabric, nodeId: NodeId): Promise<MatterServer | undefined>;
     close(): void;
 }

--- a/src/matter/common/SubjectId.ts
+++ b/src/matter/common/SubjectId.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeId } from "./NodeId";
+
+/**
+ * The meaning of a "Subject" is primarily that of describing the source for an action, using a given
+ * authentication method provided by the Secure Channel architecture.
+ * 
+ * @see [Matter Specification R1.0], section 6.6.2.1
+ */
+export type SubjectId = NodeId; // Only NodeId is supported for now...

--- a/src/matter/common/VendorId.ts
+++ b/src/matter/common/VendorId.ts
@@ -4,4 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export type VendorId = number;
+/**
+ * A Vendor Identifier (Vendor ID or VID) is a 16-bit number that uniquely identifies a particular
+ * prod­uct manufacturer, vendor, or group thereof. Each Vendor ID is statically allocated by the
+ * Connectiv­ity Standards Alliance (see [CSA Manufacturer Code Database]).
+ * 
+ * @see [Matter Specification R1.0], section 2.5.2
+ */
+export type VendorId = { vendorId: true /* Hack to force strong type checking at compile time */ };
+export const VendorId = (id: number) => id as unknown as VendorId;

--- a/src/matter/common/VendorId.ts
+++ b/src/matter/common/VendorId.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type VendorId = number;

--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -5,17 +5,15 @@
  */
 
 import { TlvType } from "../../codec/TlvCodec";
-import { AnyT, ArrayT, BooleanT, Field, ObjectT, OptionalField, Template, UnsignedIntT, UnsignedLongT } from "../../codec/TlvObjectCodec";
+import { AnyT, ArrayT, BooleanT, EnumT, Field, ObjectT, OptionalField, UnsignedIntT, UnsignedLongT } from "../../codec/TlvObjectCodec";
 
 // See project-chip src/protocols/interaction_model/StatusCodeList.h
 export const enum StatusCode {
     Success = 0x00,
     Failure = 0x01,
 }
-export const StatusCodeT = { tlvType: TlvType.UnsignedInt } as Template<StatusCode>;
-
 export const StatusResponseT = ObjectT({
-    status: Field(0, StatusCodeT),
+    status: Field(0, EnumT<StatusCode>()),
     interactionModelRevision: Field(0xFF, UnsignedIntT),
 });
 

--- a/src/matter/interaction/SubscriptionHandler.ts
+++ b/src/matter/interaction/SubscriptionHandler.ts
@@ -11,6 +11,7 @@ import { Element } from "../../codec/TlvCodec";
 import { Fabric } from "../fabric/Fabric";
 import { AttributeWithPath, Path, INTERACTION_PROTOCOL_ID } from "./InteractionServer";
 import { Time, Timer } from "../../time/Time";
+import { NodeId } from "../common/NodeId";
 
 interface PathValueVersion<T> {
     path: Path,
@@ -20,7 +21,7 @@ interface PathValueVersion<T> {
 
 export class SubscriptionHandler {
 
-    static Builder = (server: MatterDevice, fabric: Fabric, peerNodeId: bigint, attributes: AttributeWithPath[], minIntervalFloorSeconds: number, maxIntervalCeilingSeconds: number) => (subscriptionId: number) => new SubscriptionHandler(subscriptionId, server, fabric, peerNodeId, attributes, minIntervalFloorSeconds * 1000, maxIntervalCeilingSeconds * 1000);
+    static Builder = (server: MatterDevice, fabric: Fabric, peerNodeId: NodeId, attributes: AttributeWithPath[], minIntervalFloorSeconds: number, maxIntervalCeilingSeconds: number) => (subscriptionId: number) => new SubscriptionHandler(subscriptionId, server, fabric, peerNodeId, attributes, minIntervalFloorSeconds * 1000, maxIntervalCeilingSeconds * 1000);
 
     private lastUpdateTimeMs = 0;
     private readonly listener = () => this.sendUpdate();
@@ -30,7 +31,7 @@ export class SubscriptionHandler {
         readonly subscriptionId: number,
         private readonly server: MatterDevice,
         private readonly fabric: Fabric,
-        private readonly peerNodeId: bigint,
+        private readonly peerNodeId: NodeId,
         private readonly attributes: AttributeWithPath[],
         private readonly minIntervalFloorMs: number,
         private readonly maxIntervalCeilingMs: number,

--- a/src/matter/mdns/MdnsBroadcaster.ts
+++ b/src/matter/mdns/MdnsBroadcaster.ts
@@ -10,6 +10,8 @@ import { Broadcaster } from "../common/Broadcaster";
 import { bigintToBuffer } from "../../util/BigInt";
 import { getDeviceMatterQname, getFabricQname, MATTER_COMMISSION_SERVICE_QNAME, MATTER_SERVICE_QNAME, SERVICE_DISCOVERY_QNAME } from "./MdnsConsts";
 import { MdnsServer } from "../../net/MdnsServer";
+import { VendorId } from "../common/VendorId";
+import { NodeId, nodeIdToBigint } from "../common/NodeId";
 
 export class MdnsBroadcaster implements Broadcaster {
     static async create(multicastInterface?: string) {
@@ -20,7 +22,7 @@ export class MdnsBroadcaster implements Broadcaster {
         private readonly mdnsServer: MdnsServer,
     ) {}
 
-    setCommissionMode(deviceName: string, deviceType: number, vendorId: number, productId: number, discriminator: number) {
+    setCommissionMode(deviceName: string, deviceType: number, vendorId: VendorId, productId: number, discriminator: number) {
         const shortDiscriminator = (discriminator >> 8) & 0x0F;
         const instanceId = Crypto.getRandomData(8).toString("hex").toUpperCase();
         const vendorQname = `_V${vendorId}._sub.${MATTER_COMMISSION_SERVICE_QNAME}`;
@@ -63,8 +65,8 @@ export class MdnsBroadcaster implements Broadcaster {
         });
     }
 
-    setFabric(operationalId: Buffer, nodeId: bigint) {
-        const nodeIdString = bigintToBuffer(nodeId).toString("hex").toUpperCase();
+    setFabric(operationalId: Buffer, nodeId: NodeId) {
+        const nodeIdString = bigintToBuffer(nodeIdToBigint(nodeId)).toString("hex").toUpperCase();
         const operationalIdString = operationalId.toString("hex").toUpperCase();
         const fabricQname = getFabricQname(operationalIdString);
         const deviceMatterQname = getDeviceMatterQname(operationalIdString, nodeIdString);

--- a/src/matter/mdns/MdnsScanner.ts
+++ b/src/matter/mdns/MdnsScanner.ts
@@ -14,6 +14,7 @@ import { bigintToBuffer } from "../../util/BigInt";
 import { MatterServer, Scanner } from "../common/Scanner";
 import { Fabric } from "../fabric/Fabric";
 import { Time, Timer } from "../../time/Time";
+import { NodeId, nodeIdToBigint } from "../common/NodeId";
 
 type MatterServerRecordWithExpire = MatterServer & { expires: number };
 
@@ -34,8 +35,8 @@ export class MdnsScanner implements Scanner {
         this.periodicTimer = Time.getPeriodicTimer(60 * 1000 /* 1 mn */, () => this.expire()).start();
     }
 
-    async findDevice({operationalId}: Fabric, nodeId: bigint): Promise<MatterServer | undefined> {
-        const nodeIdString = bigintToBuffer(nodeId).toString("hex").toUpperCase();
+    async findDevice({operationalId}: Fabric, nodeId: NodeId): Promise<MatterServer | undefined> {
+        const nodeIdString = bigintToBuffer(nodeIdToBigint(nodeId)).toString("hex").toUpperCase();
         const operationalIdString = operationalId.toString("hex").toUpperCase();
         const deviceMatterQname = getDeviceMatterQname(operationalIdString, nodeIdString);
 

--- a/src/matter/session/Session.ts
+++ b/src/matter/session/Session.ts
@@ -5,7 +5,7 @@
  */
 
 import { Message, Packet } from "../../codec/MessageCodec";
-import { Fabric } from "../fabric/Fabric";
+import { NodeId } from "../common/NodeId";
 
 export const DEFAULT_IDLE_RETRANSMISSION_TIMEOUT_MS = 5000;
 export const DEFAULT_ACTIVE_RETRANSMISSION_TIMEOUT_MS = 300;
@@ -26,6 +26,6 @@ export interface Session<T> {
     getContext(): T;
     getId(): number;
     getPeerSessionId(): number;
-    getNodeId(): bigint | undefined;
-    getPeerNodeId(): bigint | undefined;
+    getNodeId(): NodeId | undefined;
+    getPeerNodeId(): NodeId | undefined;
 }

--- a/src/matter/session/secure/CaseClient.ts
+++ b/src/matter/session/secure/CaseClient.ts
@@ -13,13 +13,14 @@ import { MatterController } from "../../MatterController";
 import { KDFSR1_KEY_INFO, KDFSR2_INFO, KDFSR2_KEY_INFO, KDFSR3_INFO, RESUME1_MIC_NONCE, RESUME2_MIC_NONCE, EncryptedDataSigma2T, SignedDataT, TBE_DATA2_NONCE, TBE_DATA3_NONCE, EncryptedDataSigma3T } from "./CaseMessages";
 import { CaseClientMessenger } from "./CaseMessenger";
 import { Logger } from "../../../log/Logger";
+import { NodeId } from "../../common/NodeId";
 
 const logger = Logger.get("CaseClient");
 
 export class CaseClient {
     constructor() {}
 
-    async pair(client: MatterController, exchange: MessageExchange<MatterController>, fabric: Fabric, peerNodeId: bigint) {
+    async pair(client: MatterController, exchange: MessageExchange<MatterController>, fabric: Fabric, peerNodeId: NodeId) {
         const messenger = new CaseClientMessenger(exchange);
 
         // Generate pairing info

--- a/test/IntegrationTest.ts
+++ b/test/IntegrationTest.ts
@@ -30,6 +30,8 @@ import { OperationalCredentialsClusterHandler } from "../src/matter/cluster/serv
 import { ClusterClient } from "../src/matter/interaction/InteractionClient";
 import { Level, Logger } from "../src/log/Logger";
 import { getPromiseResolver } from "../src/util/Promises";
+import { VendorId } from "../src/matter/common/VendorId";
+import { NodeId } from "../src/matter/common/NodeId";
 
 const SERVER_IP = "192.168.200.1";
 const SERVER_MAC = "00:B0:D0:63:C2:26";
@@ -54,7 +56,7 @@ const CertificateDeclaration = Buffer.from("3082021906092a864886f70d010702a08202
 const deviceName = "Matter end-to-end device";
 const deviceType = 257 /* Dimmable bulb */;
 const vendorName = "node-matter";
-const vendorId = 0xFFF1;
+const vendorId = VendorId(0xFFF1);
 const productName = "Matter end-to-end device";
 const productId = 0X8001;
 const discriminator = 3840;
@@ -153,7 +155,7 @@ describe("Integration", () => {
         });
 
         it("the session is resumed if it has been established previously", async () => {
-            await client.connect(BigInt(1));
+            await client.connect(NodeId(BigInt(1)));
 
             assert.ok(true);
         });
@@ -181,7 +183,7 @@ describe("Integration", () => {
         });*/
 
         it("subscription sends updates when the value changes", async () => {
-            const interactionClient = await client.connect(BigInt(1));
+            const interactionClient = await client.connect(NodeId(BigInt(1)));
             const onOffClient = ClusterClient(interactionClient, 1, OnOffCluster);
             const startTime = Time.nowMs();
             let callback = (value: boolean, version: number) => {};

--- a/test/codec/MessageTest.ts
+++ b/test/codec/MessageTest.ts
@@ -6,6 +6,7 @@
 
 import assert from "assert";
 import { MessageCodec } from "../../src/codec/MessageCodec";
+import { NodeId } from "../../src/matter/common/NodeId";
 
 const ENCODED = Buffer.from("040000000a4ff2177ea0c8a7cb6a63520520d3640000153001204715a406c6b0496ad52039e347db8528cb69a1cb2fce6f2318552ae65e103aca250233dc240300280435052501881325022c011818", "hex");
 
@@ -13,7 +14,7 @@ const DECODED = {
     packetHeader: {
         sessionId: 0,
         sessionType: 0,
-        sourceNodeId: BigInt("5936706156730294398"),
+        sourceNodeId: NodeId(BigInt("5936706156730294398")),
         messageId: 401755914,
         destGroupId: undefined,
         destNodeId: undefined
@@ -24,7 +25,7 @@ const DECODED = {
         exchangeId: 25811,
         messageType: 0x20,
         requiresAck: true,
-        ackedMessageId: undefined
+        ackedMessageId: undefined,
       },
       payload: Buffer.from("153001204715a406c6b0496ad52039e347db8528cb69a1cb2fce6f2318552ae65e103aca250233dc240300280435052501881325022c011818", "hex"),
 };
@@ -38,7 +39,7 @@ const DECODED_2 = {
         sourceNodeId: undefined,
         messageId: 2031257377,
         destGroupId: undefined,
-        destNodeId: BigInt("5936706156730294398")
+        destNodeId: NodeId(BigInt("5936706156730294398")),
       },
       payloadHeader: {
         protocolId: 0,

--- a/test/matter/fabric/FabricTest.ts
+++ b/test/matter/fabric/FabricTest.ts
@@ -6,6 +6,8 @@
 
 import assert from "assert";
 import { Crypto } from "../../../src/crypto/Crypto";
+import { NodeId } from "../../../src/matter/common/NodeId";
+import { VendorId } from "../../../src/matter/common/VendorId";
 import { Fabric, FabricBuilder } from "../../../src/matter/fabric/Fabric";
 
 const ROOT_CERT = Buffer.from("153001010024020137032414001826048012542826058015203b37062414001824070124080130094104d89eb7e3f3226d0918f4b85832457bb9981bca7aaef58c18fb5ec07525e472b2bd1617fb75ee41bd388f94ae6a6070efc896777516a5c54aff74ec0804cdde9d370a3501290118240260300414e766069362d7e35b79687161644d222bdde93a68300514e766069362d7e35b79687161644d222bdde93a6818300b404e8fb06526f0332b3e928166864a6d29cade53fb5b8918a6d134d0994bf1ae6dce6762dcba99e80e96249d2f1ccedb336b26990f935dba5a0b9e5b4c9e5d1d8f1818181824ff0118", "hex");
@@ -14,18 +16,18 @@ const IPK_KEY = Buffer.from("74656d706f726172792069706b203031", "hex");
 const OPERATIONAL_ID = Buffer.from("d559af361549a9a2", "hex");
 
 const TEST_FABRIC_ID = BigInt("0x2906C908D115D362");
-const TEST_NODE_ID = BigInt("0xCD5544AA7B13EF14");
+const TEST_NODE_ID = NodeId(BigInt("0xCD5544AA7B13EF14"));
 const TEST_ROOT_PUBLIC_KEY = Buffer.from("044a9f42b1ca4840d37292bbc7f6a7e11e22200c976fc900dbc98a7a383a641cb8254a2e56d4e295a847943b4e3897c4a773e930277b4d9fbede8a052686bfacfa", "hex");
 const TEST_IDENTITY_PROTECTION_KEY = Buffer.from("9bc61cd9c62a2df6d64dfcaa9dc472d4", "hex");
 const TEST_RANDOM = Buffer.from("7e171231568dfa17206b3accf8faec2f4d21b580113196f47c7c4deb810a73dc", "hex");
 const EXPECTED_DESTINATION_ID = Buffer.from("dc35dd5fc9134cc5544538c9c3fc4297c1ec3370c839136a80e10796451d4c53", "hex");
 
 const TEST_RANDOM_2 = Buffer.from("147546b42b4212ae62e3b393b973e7892e02a86d387d8f4829b0861495b5743a", "hex");
-const TEST_NODE_ID_2 = BigInt("0x0000000000000009");
+const TEST_NODE_ID_2 = NodeId(BigInt("0x0000000000000009"));
 const EXPECTED_DESTINATION_ID_2 = Buffer.from("e62053e0b5226773ab96833d79133c865ddb5a67c9ea932471c73405afcd68da", "hex");
 
 const TEST_FABRIC_ID_3 = BigInt("0x0000000000000001");
-const TEST_NODE_ID_3 = BigInt("0x0000000000000055");
+const TEST_NODE_ID_3 = NodeId(BigInt("0x0000000000000055"));
 const TEST_ROOT_PUBLIC_KEY_3 = Buffer.from("04d89eb7e3f3226d0918f4b85832457bb9981bca7aaef58c18fb5ec07525e472b2bd1617fb75ee41bd388f94ae6a6070efc896777516a5c54aff74ec0804cdde9d", "hex");
 const TEST_IDENTITY_PROTECTION_KEY_3 = Buffer.from("0c677d9b5ac585827b577470bd9bd516", "hex");
 const TEST_RANDOM_3 = Buffer.from("0b2a71876d3d090d37cb5286168ab9be0d2e7e0ccbedc1f55331b8a8051ee02f", "hex");
@@ -34,7 +36,7 @@ const EXPECTED_DESTINATION_ID_3 = Buffer.from("f7f7009606c61927af62502067581b4b0
 describe("FabricBuilder", () => {
     context("build", () => {
         const builder = new FabricBuilder();
-        builder.setVendorId(0);
+        builder.setVendorId(VendorId(0));
         builder.setRootCert(ROOT_CERT);
         builder.setOperationalCert(NEW_OP_CERT);
         builder.setIdentityProtectionKey(IPK_KEY);
@@ -57,7 +59,7 @@ describe("Fabric", () => {
 
     context("getDestinationId", () => {
         it("generates the correct destination ID", () => {
-            const fabric = new Fabric(TEST_FABRIC_ID, TEST_NODE_ID, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY, Crypto.createKeyPair(), 0, Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY, undefined, Buffer.alloc(0)); 
+            const fabric = new Fabric(TEST_FABRIC_ID, TEST_NODE_ID, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY, Crypto.createKeyPair(), VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY, undefined, Buffer.alloc(0)); 
 
             const result = fabric.getDestinationId(TEST_NODE_ID, TEST_RANDOM);
 
@@ -66,7 +68,7 @@ describe("Fabric", () => {
 
         it("generates the correct destination ID 2", async () => {
             const builder = new FabricBuilder();
-            builder.setVendorId(0);
+            builder.setVendorId(VendorId(0));
             builder.setRootCert(ROOT_CERT);
             builder.setOperationalCert(NEW_OP_CERT);
             builder.setIdentityProtectionKey(IPK_KEY);
@@ -78,7 +80,7 @@ describe("Fabric", () => {
         });
 
         it("generates the correct destination ID 3", async () => {
-            const fabric = new Fabric(TEST_FABRIC_ID_3, TEST_NODE_ID_3, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY_3, Crypto.createKeyPair(), 0, Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY_3, undefined, Buffer.alloc(0)); 
+            const fabric = new Fabric(TEST_FABRIC_ID_3, TEST_NODE_ID_3, Buffer.alloc(0), TEST_ROOT_PUBLIC_KEY_3, Crypto.createKeyPair(), VendorId(0), Buffer.alloc(0), Buffer.alloc(0), TEST_IDENTITY_PROTECTION_KEY_3, undefined, Buffer.alloc(0)); 
 
             const result = fabric.getDestinationId(TEST_NODE_ID_3, TEST_RANDOM_3);
 

--- a/test/matter/interaction/InteractionProtocolTest.ts
+++ b/test/matter/interaction/InteractionProtocolTest.ts
@@ -12,6 +12,7 @@ import { MessageExchange } from "../../../src/matter/common/MessageExchange";
 import { DEVICE } from "../../../src/matter/common/DeviceTypes";
 import { MatterDevice } from "../../../src/matter/MatterDevice";
 import { BasicInformationCluster } from "../../../src/matter/cluster/BasicInformationCluster";
+import { VendorId } from "../../../src/matter/common/VendorId";
 
 const READ_REQUEST: ReadRequest = {
     interactionModelRevision: 1,
@@ -64,7 +65,7 @@ describe("InteractionProtocol", () => {
                     new ClusterServer(BasicInformationCluster, {
                         dataModelRevision: 1,
                         vendorName: "vendor",
-                        vendorId: 1,
+                        vendorId: VendorId(1),
                         productName: "product",
                         productId: 2,
                         nodeLabel: "",

--- a/test/mdns/MdnsTest.ts
+++ b/test/mdns/MdnsTest.ts
@@ -15,6 +15,7 @@ import { NetworkFake } from "../../src/net/fake/NetworkFake";
 import { Network } from "../../src/net/Network";
 import { MdnsScanner } from "../../src/matter/mdns/MdnsScanner";
 import { Fabric } from "../../src/matter/fabric/Fabric";
+import { NodeId } from "../../src/matter/common/NodeId";
 
 const SERVER_IP = "192.168.200.1";
 const SERVER_MAC = "00:B0:D0:63:C2:26";
@@ -25,7 +26,7 @@ const serverNetwork = new NetworkFake([ {ip: SERVER_IP, mac: SERVER_MAC} ]);
 const clientNetwork = new NetworkFake([ {ip: CLIENT_IP, mac: CLIENT_MAC} ]);
 
 const OPERATIONAL_ID = bigintToBuffer(BigInt(24));
-const NODE_ID = BigInt(1);
+const NODE_ID = NodeId(BigInt(1));
 
 describe("MDNS", () => {
     var broadcaster: MdnsBroadcaster;


### PR DESCRIPTION
This is kind of a hacky way of doing it: force casting the raw type to a specialized type.

The clean way would have been to introduce a method that the deserializer can use to transform to raw type to the internal typed version.
If you don't like the hacky way, let me know and I can do the clean version.
We will probably need to the clean version at some point...