### PR TITLE
small updates for BasicInformationCluster and add documents

### DIFF
--- a/src/Specifications.ts
+++ b/src/Specifications.ts
@@ -6,3 +6,9 @@
 
 /** {@link https://csa-iot.org/developer-resource/specifications-download-request/ Matter Core Specification 1.0} */
 export interface MatterCoreSpecificationV1_0 {}
+
+/** {@link https://csa-iot.org/developer-resource/specifications-download-request/ Matter Application Cluster Specification 1.0} */
+export interface MatterApplicationClusterSpecificationV1_0 {}
+
+/** {@link https://csa-iot.org/developer-resource/specifications-download-request/ Matter Device Library Specification 1.0} */
+export interface MatterDeviceLibrarySpecificationV1_0 {}

--- a/src/matter/cluster/BasicInformationCluster.ts
+++ b/src/matter/cluster/BasicInformationCluster.ts
@@ -11,13 +11,13 @@ import { AccessLevel, Attribute, Cluster, Event, EventPriority, OptionalAttribut
 import { MatterCoreSpecificationV1_0 } from "../../Specifications";
 
 
-/** 
+/**
  * Provides constant values related to overall global capabilities of this Node, that are not cluster-specific.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § 11.1.6.2
  */
 const CapabilityMinimaT = ObjectT({
-    /** Indicates the minimum number of concurrent CASE sessions that are sup­ported per fabric. */
+    /** Indicates the minimum number of concurrent CASE sessions that are supported per fabric. */
     caseSessionsPerFabric: Field(0, BoundedUnsignedIntT({ min: 3 })),
 
     /** Indicate the actual minimum number of concurrent subscriptions supported per fabric. */
@@ -28,29 +28,36 @@ const CapabilityMinimaT = ObjectT({
  * This cluster provides attributes and events for determining basic information about Nodes, which supports both
  * commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
  * which apply to the whole Node. Also allows setting user device information such as location.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § 11.1
  */
 export const BasicInformationCluster = Cluster({
     id: 0x28,
     name: "Basic Information",
 
+    /* TODO We need to add the global Attributes/Elements, see Core Spec 7.13 - with new structure maybe like that?
+            And yes some attributes could be automatically generated from the registered command implementations or such.
+    globalClusterAttributes: {
+        clusterRevision: 1
+    },
+    */
+
     /** @see {@link MatterCoreSpecificationV1_0} § 11.1.6.3 */
     attributes: {
         /** Revision number of the Data Model against which the Node is certified */
-        dataModelRevision: Attribute(0, UnsignedIntT),
+        dataModelRevision: Attribute(0, BoundedUnsignedIntT({ min: 0, max: 0xFFFF })),
 
-        /** Human readable (displayable) name of the vendor for the Node. */
+        /** Human-readable (displayable) name of the vendor for the Node. */
         vendorName: Attribute(1, StringT({ maxLength: 32 })),
 
         /** Specifies the {@link VendorId}. */
         vendorId: Attribute(2, VendorIdT),
 
-        /** Human readable name of the model for the Node such as the model number assigned by the vendor. */
+        /** Human-readable name of the model for the Node such as the model number assigned by the vendor. */
         productName: Attribute(3, StringT({ maxLength: 32 })),
 
         /** Product ID assigned by the vendor that is unique to the specific product of the Node. */
-        productId: Attribute(4, UnsignedIntT),
+        productId: Attribute(4, BoundedUnsignedIntT({ min: 0, max: 0xFFFF })),
 
         /** User defined name for the Node. It is set during initial commissioning and may be updated by further reconfigurations. */
         nodeLabel: WritableAttribute(5, StringT({ maxLength: 32 }), { default: "", writeAcl: AccessLevel.Manage } ),
@@ -59,15 +66,15 @@ export const BasicInformationCluster = Cluster({
         location: WritableAttribute(6, StringT({ length: 2 }), { default: "XX", writeAcl: AccessLevel.Administer } ),
 
         /** Version number of the hardware of the Node. The meaning of its value, and the versioning scheme, are vendor defined. */
-        hardwareVersion: Attribute(7, UnsignedIntT, { default: 0 }),
+        hardwareVersion: Attribute(7, BoundedUnsignedIntT({ min: 0, max: 0xFFFF }), { default: 0 }),
 
-        /** Human readable representation of the {@link BasicInformationCluster.attributes.hardwareVersion hardwareVersion} attribute. */
+        /** Human-readable representation of the {@link BasicInformationCluster.attributes.hardwareVersion hardwareVersion} attribute. */
         hardwareVersionString: Attribute(8, StringT({ minLength: 1, maxLength: 64 })),
 
         /** Current version number for the software running on this Node. A larger value is newer than a lower value. */
         softwareVersion: Attribute(9, UnsignedIntT, { default: 0 }),
 
-        /** Human readable representation of the {@link BasicInformationCluster.attributes.softwareVersion softwareVersion} attribute. */
+        /** Human-readable representation of the {@link BasicInformationCluster.attributes.softwareVersion softwareVersion} attribute. */
         softwareVersionString: Attribute(10, StringT({ minLength: 1, maxLength: 64 })),
 
         /** Node manufacturing date formatted with YYYYMMDD. The additional 8 characters might include other vendor related information. */
@@ -94,7 +101,7 @@ export const BasicInformationCluster = Cluster({
         /** Unique identifier for the device, which is constructed in a manufacturer specific manner, updated during factory reset. */
         uniqueId: OptionalAttribute(18, StringT({ maxLength: 32 })),
 
-        /** Minimum guaranteed value for some system-wide, not cluster-specific, resource capa­bilities. */
+        /** Minimum guaranteed value for some system-wide, not cluster-specific, resource capabilities. */
         capabilityMinima: Attribute(19, CapabilityMinimaT, { default: { caseSessionsPerFabric: 3, subscriptionsPerFabric: 3 } }),
     },
 
@@ -109,7 +116,7 @@ export const BasicInformationCluster = Cluster({
         /** Fired prior to permanently leaving a given Fabric. */
         leave: OptionalEvent(2, EventPriority.Info, { fabricIndex: Field(0, FabricIndexT) }),
 
-        /** Fired when there is a change in the {@link BasicInformationCluster.attributes.reachable reachable} attribute */
+        /** Fired when there is a change in the {@link BasicInformationCluster.attributes.reachable reachable} attribute. */
         reachableChanged: OptionalEvent(3, EventPriority.Info, { reachableNewValue: Field(0, BooleanT) }),
     },
 });

--- a/src/matter/cluster/BasicInformationCluster.ts
+++ b/src/matter/cluster/BasicInformationCluster.ts
@@ -29,18 +29,13 @@ const CapabilityMinimaT = ObjectT({
  * commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
  * which apply to the whole Node. Also allows setting user device information such as location.
  *
+ * clusterRevision: 1
+ *
  * @see {@link MatterCoreSpecificationV1_0} § 11.1
  */
 export const BasicInformationCluster = Cluster({
     id: 0x28,
     name: "Basic Information",
-
-    /* TODO We need to add the global Attributes/Elements, see Core Spec 7.13 - with new structure maybe like that?
-            And yes some attributes could be automatically generated from the registered command implementations or such.
-    globalClusterAttributes: {
-        clusterRevision: 1
-    },
-    */
 
     /** @see {@link MatterCoreSpecificationV1_0} § 11.1.6.3 */
     attributes: {


### PR DESCRIPTION
As a follow up to your #100 here is a small update for BasicInformationCluster to sync on two topics.
Additionally it adds the other two basic documents to the Specification file (will be used soon)