### PR TITLE
Fix object type in Descriptor cluster

### DIFF
--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -104,8 +104,8 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                 default:
                     throw new Error(`Unsupported message type ${message.payloadHeader.messageType}`);
             }
-        } catch (error) {
-            logger.error(error);
+        } catch (error: any) {
+            logger.error(error.stack ?? error);
             await this.sendStatus(StatusCode.Failure);
         } finally {
             this.exchange.close();

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -19,6 +19,7 @@ import { Logger } from "../../log/Logger";
 import { DeviceTypeId } from "../common/DeviceTypeId";
 import { ClusterId } from "../common/ClusterId";
 import { TlvStream, TypeFromBitSchema } from "@project-chip/matter.js";
+import { EndpointNumber } from "../common/EndpointNumber";
 
 export const INTERACTION_PROTOCOL_ID = 0x0001;
 
@@ -111,9 +112,9 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
 
         // Add part list if the endpoint is not root
         if (endpointId !== 0) {
-            const rootPartsListAttribute = this.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = this.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
             if (rootPartsListAttribute === undefined) throw new Error("The root endpoint should be added first!");
-            rootPartsListAttribute.set([...rootPartsListAttribute.get(), endpointId]);
+            rootPartsListAttribute.set([...rootPartsListAttribute.get(), new EndpointNumber(endpointId)]);
         }
 
         return this;

--- a/test/IntegrationTest.ts
+++ b/test/IntegrationTest.ts
@@ -162,6 +162,15 @@ describe("Integration", () => {
         });
     });
 
+
+    context("attributes", () => {
+        it("get all attributes", async () => {
+            await (await client.connect(new NodeId(BigInt(1)))).getAllAttributes();
+
+            assert.ok(true);
+        });
+    });
+
     context("subscription", () => {
         /*it("subscription sends regular updates", async () => {
             const interactionClient = await client.connect(BigInt(1));


### PR DESCRIPTION
The endpointId is now an EndpointNumber object instead of a raw number.
