### PR TITLE
Allow Hierarchical Endpoint structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /node_modules
+/.idea

--- a/src/matter/cluster/BridgedDeviceBasicInformationCluster.ts
+++ b/src/matter/cluster/BridgedDeviceBasicInformationCluster.ts
@@ -20,7 +20,7 @@ import { MatterCoreSpecificationV1_0, TlvBoolean, TlvField, TlvString, TlvString
  *
  * @see {@link MatterCoreSpecificationV1_0} § 9.13
  */
-export const BasicInformationCluster = Cluster({
+export const BridgedDeviceBasicInformationCluster = Cluster({
     id: 0x39,
     name: "Bridged Device Basic Information",
     revision: 1,

--- a/src/matter/cluster/Cluster.ts
+++ b/src/matter/cluster/Cluster.ts
@@ -19,17 +19,17 @@ export interface OptionalAttribute<T> extends Attribute<T> { optional: true }
 export interface WritableAttribute<T> extends Attribute<T> { writable: true }
 export interface OptionalWritableAttribute<T> extends OptionalAttribute<T> { writable: true }
 export type AttributeJsType<T extends Attribute<any>> = T extends Attribute<infer JsType> ? JsType : never;
-interface AttributeOptions<T> { default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel };
+interface AttributeOptions<T> { default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel }
 export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): Attribute<T> => ({ id, schema, optional: false, writable: false, default: conformanceValue, readAcl });
 export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalAttribute<T> => ({ id, schema, optional: true, writable: false, default: conformanceValue, readAcl });
 export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: false, writable: true, default: conformanceValue, readAcl, writeAcl });
-export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: true, writable: true, default: conformanceValue, readAcl, writeAcl });
+export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalWritableAttribute<T> => ({ id, schema, optional: true, writable: true, default: conformanceValue, readAcl, writeAcl });
 
 /* Interfaces and helper methods to define a cluster command */
 export const TlvNoArguments = TlvObject({});
 export const TlvNoResponse = TlvVoid;
-export interface Command<RequestT, ResponseT> { optional: boolean, requestId: number, requestSchema: TlvSchema<RequestT>, responseId: number, responseSchema: TlvSchema<ResponseT> };
-export interface OptionalCommand<RequestT, ResponseT> extends Command<RequestT, ResponseT> { optional: true };
+export interface Command<RequestT, ResponseT> { optional: boolean, requestId: number, requestSchema: TlvSchema<RequestT>, responseId: number, responseSchema: TlvSchema<ResponseT> }
+export interface OptionalCommand<RequestT, ResponseT> extends Command<RequestT, ResponseT> { optional: true }
 export type ResponseType<T extends Command<any, any>> = T extends OptionalCommand<any, infer ResponseT> ? ResponseT | undefined : (T extends Command<any, infer ResponseT> ? ResponseT : never);
 export type RequestType<T extends Command<any, any>> = T extends Command<infer RequestT, any> ? RequestT : never;
 export const Command = <RequestT, ResponseT>(requestId: number, requestSchema: TlvSchema<RequestT>, responseId: number, responseSchema: TlvSchema<ResponseT>): Command<RequestT, ResponseT> => ({ optional: false, requestId, requestSchema, responseId, responseSchema });

--- a/src/matter/cluster/LabelCluster.ts
+++ b/src/matter/cluster/LabelCluster.ts
@@ -13,10 +13,10 @@ import { MatterCoreSpecificationV1_0, TlvArray, TlvField, TlvObject, TlvString }
  * @see {@link MatterCoreSpecificationV1_0} § 9.7.5.1
  */
 const TlvLabel = TlvObject({
-    /** Contains a string as label without a further defined semantic n this base cluster. */
+    /** Contains a string as label without a further defined semantic in this base cluster. */
     label: TlvField(0, TlvString.bound( { length: 16 } )), /* default: "" */
 
-    /** Contains a string as value without a further defined semantic n this base cluster. */
+    /** Contains a string as value without a further defined semantic in this base cluster. */
     value: TlvField(1, TlvString.bound( { length: 16 } )), /* default: "" */
 });
 

--- a/src/matter/common/DeviceTypes.ts
+++ b/src/matter/common/DeviceTypes.ts
@@ -5,9 +5,9 @@
  */
 import { MatterDeviceLibrarySpecificationV1_0 } from "@project-chip/matter.js";
 
-export type DeviceTypeType = { name: string, code: number};
+export type Device = { name: string, code: number};
 
-export const DEVICE: Record<string, DeviceTypeType> = {
+export const DEVICE: { [name: string]: Device } = {
     // Utility Device Types
     /**
      * This represents a Root Node for devices.

--- a/src/matter/common/DeviceTypes.ts
+++ b/src/matter/common/DeviceTypes.ts
@@ -5,7 +5,9 @@
  */
 import { MatterDeviceLibrarySpecificationV1_0 } from "@project-chip/matter.js";
 
-export const DEVICE = {
+export type DeviceTypeType = { name: string, code: number};
+
+export const DEVICE: Record<string, DeviceTypeType> = {
     // Utility Device Types
     /**
      * This represents a Root Node for devices.

--- a/src/matter/interaction/Endpoint.ts
+++ b/src/matter/interaction/Endpoint.ts
@@ -1,0 +1,106 @@
+import { DescriptorCluster } from "../cluster/DescriptorCluster";
+import { DeviceTypeId } from "../common/DeviceTypeId";
+import { ClusterId } from "../common/ClusterId";
+import { AttributeServer } from "../cluster/server/AttributeServer";
+import { EndpointNumber } from "../common/EndpointNumber";
+import { ClusterServer, Path, pathToId } from "./InteractionServer";
+import { CommandServer } from "../cluster/server/CommandServer";
+
+export class Endpoint {
+
+    private readonly mainEndpointId: number;
+    readonly endpoints = new Map<number, { deviceTypes: { name: string, code: number}[], clusters: Map<number, ClusterServer<any>> }>();
+    readonly attributes = new Map<string, AttributeServer<any>>();
+    readonly attributePaths = new Array<Path>();
+    readonly commands = new Map<string, CommandServer<any, any>>();
+    readonly commandPaths = new Array<Path>();
+
+    constructor(endpointId: number, deviceTypes: { name: string, code: number }[], clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
+        this.mainEndpointId = endpointId;
+        return this.addEndpoint(endpointId, deviceTypes, clusters, childrenEndpoints);
+    }
+
+    addEndpoint(endpointId: number, deviceTypes: { name: string, code: number }[], clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
+        // Add the descriptor cluster
+        const descriptorCluster = new ClusterServer(DescriptorCluster, {}, {
+            deviceTypeList: deviceTypes.map(deviceType => ({type: new DeviceTypeId(deviceType.code), revision: 1})),
+            serverList: [],
+            clientList: [],
+            partsList: [],
+        }, {});
+        clusters.unshift(descriptorCluster);
+        descriptorCluster.attributes.serverList.set(clusters.map(({id}) => new ClusterId(id)));
+
+        const clusterMap = new Map<number, ClusterServer<any>>();
+        clusters.forEach(cluster => {
+            const {id: clusterId, attributes, commands} = cluster;
+            clusterMap.set(clusterId, cluster);
+            // Add attributes
+            for (const name in attributes) {
+                const attribute = attributes[name];
+                const path = {endpointId, clusterId, id: attribute.id};
+                this.attributes.set(pathToId(path), attribute);
+                this.attributePaths.push(path);
+            }
+
+            // Add commands
+            commands.forEach(command => {
+                const path = {endpointId, clusterId, id: command.invokeId};
+                this.commands.set(pathToId(path), command);
+                this.commandPaths.push(path);
+            });
+        });
+
+        this.endpoints.set(endpointId, {deviceTypes, clusters: clusterMap});
+
+        const parentPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = this.attributes.get(pathToId({
+            endpointId: this.mainEndpointId,
+            clusterId: DescriptorCluster.id,
+            id: DescriptorCluster.attributes.partsList.id
+        }));
+
+        if (parentPartsListAttribute === undefined) throw new Error(`Descriptor CLuster of endpoint ${this.mainEndpointId} not found.`);
+        const newPartsList = parentPartsListAttribute.get();
+
+        // Add all data from the child endpoints
+        if (childrenEndpoints) {
+            childrenEndpoints.forEach(children => {
+                children.endpoints.forEach((endpointDetails, endpoint) => {
+                    this.endpoints.set(endpoint, endpointDetails);
+                });
+
+                children.attributes.forEach((attributeDetails, attribute) => {
+                    this.attributes.set(attribute, attributeDetails);
+                });
+                this.attributePaths.push(...children.attributePaths);
+
+                children.commands.forEach((commandDetails, command) => {
+                    this.commands.set(command, commandDetails);
+                });
+                this.commandPaths.push(...children.commandPaths);
+
+                const childrenPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = this.attributes.get(pathToId({
+                    endpointId: children.mainEndpointId,
+                    clusterId: DescriptorCluster.id,
+                    id: DescriptorCluster.attributes.partsList.id
+                }));
+                if (childrenPartsListAttribute === undefined) throw new Error(`Descriptor CLuster of endpoint ${children.mainEndpointId} not found.`);
+                const childrenPartsList = childrenPartsListAttribute.get();
+                if (children.mainEndpointId !== undefined) {
+                    newPartsList.push(new EndpointNumber(children.mainEndpointId));
+                }
+                if (childrenPartsList.length > 0) {
+                    newPartsList.push(...childrenPartsList);
+                }
+            });
+        }
+
+        // Add part list if the endpoint is not current main endpoint
+        if (endpointId !== this.mainEndpointId) {
+            newPartsList.push(new EndpointNumber(endpointId));
+        }
+        parentPartsListAttribute.set(newPartsList);
+
+        return this;
+    }
+}

--- a/src/matter/interaction/Endpoint.ts
+++ b/src/matter/interaction/Endpoint.ts
@@ -5,25 +5,24 @@ import { AttributeServer } from "../cluster/server/AttributeServer";
 import { EndpointNumber } from "../common/EndpointNumber";
 import { ClusterServer, Path, pathToId } from "./InteractionServer";
 import { CommandServer } from "../cluster/server/CommandServer";
-import { DeviceTypeType } from "../common/DeviceTypes";
-
-export type MinimumOneDeviceTypeArray = [DeviceTypeType, ...DeviceTypeType[]];
+import { Device } from "../common/DeviceTypes";
+import { AtLeastOne } from "../../util/Array";
 
 export class Endpoint {
 
     private readonly mainEndpointId: number;
-    readonly endpoints = new Map<number, { deviceTypes: MinimumOneDeviceTypeArray, clusters: Map<number, ClusterServer<any>> }>();
+    readonly endpoints = new Map<number, { deviceTypes: AtLeastOne<Device>, clusters: Map<number, ClusterServer<any>> }>();
     readonly attributes = new Map<string, AttributeServer<any>>();
     readonly attributePaths = new Array<Path>();
     readonly commands = new Map<string, CommandServer<any, any>>();
     readonly commandPaths = new Array<Path>();
 
-    constructor(endpointId: number, deviceTypes: MinimumOneDeviceTypeArray, clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
+    constructor(endpointId: number, deviceTypes: AtLeastOne<Device>, clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
         this.mainEndpointId = endpointId;
         return this.addEndpoint(endpointId, deviceTypes, clusters, childrenEndpoints);
     }
 
-    addEndpoint(endpointId: number, deviceTypes: MinimumOneDeviceTypeArray, clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
+    addEndpoint(endpointId: number, deviceTypes: AtLeastOne<Device>, clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
         // Add the descriptor cluster
         const descriptorCluster = new ClusterServer(DescriptorCluster, {}, {
             deviceTypeList: deviceTypes.map(deviceType => ({type: new DeviceTypeId(deviceType.code), revision: 1})),

--- a/src/matter/interaction/Endpoint.ts
+++ b/src/matter/interaction/Endpoint.ts
@@ -5,22 +5,25 @@ import { AttributeServer } from "../cluster/server/AttributeServer";
 import { EndpointNumber } from "../common/EndpointNumber";
 import { ClusterServer, Path, pathToId } from "./InteractionServer";
 import { CommandServer } from "../cluster/server/CommandServer";
+import { DeviceTypeType } from "../common/DeviceTypes";
+
+export type MinimumOneDeviceTypeArray = [DeviceTypeType, ...DeviceTypeType[]];
 
 export class Endpoint {
 
     private readonly mainEndpointId: number;
-    readonly endpoints = new Map<number, { deviceTypes: { name: string, code: number}[], clusters: Map<number, ClusterServer<any>> }>();
+    readonly endpoints = new Map<number, { deviceTypes: MinimumOneDeviceTypeArray, clusters: Map<number, ClusterServer<any>> }>();
     readonly attributes = new Map<string, AttributeServer<any>>();
     readonly attributePaths = new Array<Path>();
     readonly commands = new Map<string, CommandServer<any, any>>();
     readonly commandPaths = new Array<Path>();
 
-    constructor(endpointId: number, deviceTypes: { name: string, code: number }[], clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
+    constructor(endpointId: number, deviceTypes: MinimumOneDeviceTypeArray, clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
         this.mainEndpointId = endpointId;
         return this.addEndpoint(endpointId, deviceTypes, clusters, childrenEndpoints);
     }
 
-    addEndpoint(endpointId: number, deviceTypes: { name: string, code: number }[], clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
+    addEndpoint(endpointId: number, deviceTypes: MinimumOneDeviceTypeArray, clusters: ClusterServer<any>[], childrenEndpoints?: Endpoint[]) {
         // Add the descriptor cluster
         const descriptorCluster = new ClusterServer(DescriptorCluster, {}, {
             deviceTypeList: deviceTypes.map(deviceType => ({type: new DeviceTypeId(deviceType.code), revision: 1})),

--- a/src/matter/interaction/Endpoint.ts
+++ b/src/matter/interaction/Endpoint.ts
@@ -32,7 +32,7 @@ export class Endpoint {
             partsList: [],
         }, {});
         clusters.unshift(descriptorCluster);
-        descriptorCluster.attributes.serverList.set(clusters.map(({id}) => new ClusterId(id)));
+        descriptorCluster.attributes.serverList.setLocal(clusters.map(({id}) => new ClusterId(id)));
 
         const clusterMap = new Map<number, ClusterServer<any>>();
         clusters.forEach(cluster => {
@@ -63,7 +63,7 @@ export class Endpoint {
         }));
 
         if (parentPartsListAttribute === undefined) throw new Error(`Descriptor CLuster of endpoint ${this.mainEndpointId} not found.`);
-        const newPartsList = parentPartsListAttribute.get();
+        const newPartsList = parentPartsListAttribute.getLocal();
 
         // Add all data from the child endpoints
         if (childrenEndpoints) {
@@ -88,7 +88,7 @@ export class Endpoint {
                     id: DescriptorCluster.attributes.partsList.id
                 }));
                 if (childrenPartsListAttribute === undefined) throw new Error(`Descriptor CLuster of endpoint ${children.mainEndpointId} not found.`);
-                const childrenPartsList = childrenPartsListAttribute.get();
+                const childrenPartsList = childrenPartsListAttribute.getLocal();
                 if (children.mainEndpointId !== undefined) {
                     newPartsList.push(new EndpointNumber(children.mainEndpointId));
                 }
@@ -102,7 +102,7 @@ export class Endpoint {
         if (endpointId !== this.mainEndpointId) {
             newPartsList.push(new EndpointNumber(endpointId));
         }
-        parentPartsListAttribute.set(newPartsList);
+        parentPartsListAttribute.setLocal(newPartsList);
 
         return this;
     }

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -77,11 +77,11 @@ function toHex(value: number | undefined) {
 const logger = Logger.get("InteractionProtocol");
 
 export class InteractionServer implements ProtocolHandler<MatterDevice> {
-    readonly endpoints = new Map<number, { name: string, code: number, clusters: Map<number, ClusterServer<any>> }>();
-    readonly attributes = new Map<string, AttributeServer<any>>();
-    readonly attributePaths = new Array<Path>();
-    readonly commands = new Map<string, CommandServer<any, any>>();
-    readonly commandPaths = new Array<Path>();
+    private readonly endpoints = new Map<number, { name: string, code: number, clusters: Map<number, ClusterServer<any>> }>();
+    private readonly attributes = new Map<string, AttributeServer<any>>();
+    private readonly attributePaths = new Array<Path>();
+    private readonly commands = new Map<string, CommandServer<any, any>>();
+    private readonly commandPaths = new Array<Path>();
 
     constructor() {}
 

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -77,11 +77,11 @@ function toHex(value: number | undefined) {
 const logger = Logger.get("InteractionProtocol");
 
 export class InteractionServer implements ProtocolHandler<MatterDevice> {
-    private readonly endpoints = new Map<number, { name: string, code: number, clusters: Map<number, ClusterServer<any>> }>();
-    private readonly attributes = new Map<string, AttributeServer<any>>();
-    private readonly attributePaths = new Array<Path>();
-    private readonly commands = new Map<string, CommandServer<any, any>>();
-    private readonly commandPaths = new Array<Path>();
+    readonly endpoints = new Map<number, { name: string, code: number, clusters: Map<number, ClusterServer<any>> }>();
+    readonly attributes = new Map<string, AttributeServer<any>>();
+    readonly attributePaths = new Array<Path>();
+    readonly commands = new Map<string, CommandServer<any, any>>();
+    readonly commandPaths = new Array<Path>();
 
     constructor() {}
 

--- a/src/matter/session/secure/PaseClient.ts
+++ b/src/matter/session/secure/PaseClient.ts
@@ -42,7 +42,7 @@ export class PaseClient {
         await messenger.waitForSuccess();
         const secureSession = await client.createSecureSession(sessionId, undefined, UNDEFINED_NODE_ID, peerSessionId, Ke, new ByteArray(0), true, false);
         messenger.close();
-        logger.info(`Pase client: Paired succesfully with ${messenger.getChannelName()}`);
+        logger.info(`Pase client: Paired successfully with ${messenger.getChannelName()}`);
 
         return secureSession;
     }

--- a/src/util/Array.ts
+++ b/src/util/Array.ts
@@ -1,0 +1,9 @@
+/**
+ * Array types
+ *
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type AtLeastOne<T> = [T, ...T[]];

--- a/test/matter/interaction/EndpointTest.ts
+++ b/test/matter/interaction/EndpointTest.ts
@@ -43,7 +43,7 @@ describe("Endpoint", () => {
             assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
 
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(rootPartsListAttribute?.get(), []);
+            assert.deepEqual(rootPartsListAttribute?.getLocal(), []);
 
             assert.equal(rootEndpoint.attributePaths.length, 21);
             assert.equal(rootEndpoint.commandPaths.length, 0);
@@ -88,7 +88,7 @@ describe("Endpoint", () => {
             assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(OnOffCluster.id), true);
 
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1)]);
+            assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1)]);
 
             assert.equal(rootEndpoint.attributePaths.length, 30);
             assert.equal(rootEndpoint.commandPaths.length, 3);
@@ -137,10 +137,10 @@ describe("Endpoint", () => {
             assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(OnOffCluster.id), true);
 
             const aggregatorPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 1, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(aggregatorPartsListAttribute?.get(), [new EndpointNumber(11)]);
+            assert.deepEqual(aggregatorPartsListAttribute?.getLocal(), [new EndpointNumber(11)]);
 
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1), new EndpointNumber(11)]);
+            assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(11)]);
 
             assert.equal(rootEndpoint.attributePaths.length, 36);
             assert.equal(rootEndpoint.commandPaths.length, 3);
@@ -207,10 +207,10 @@ describe("Endpoint", () => {
             assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(OnOffCluster.id), true);
 
             const aggregatorPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 1, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(aggregatorPartsListAttribute?.get(), [new EndpointNumber(11), new EndpointNumber(12)]);
+            assert.deepEqual(aggregatorPartsListAttribute?.getLocal(), [new EndpointNumber(11), new EndpointNumber(12)]);
 
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12)]);
+            assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12)]);
 
             assert.equal(rootEndpoint.attributePaths.length, 53);
             assert.equal(rootEndpoint.commandPaths.length, 6);
@@ -246,7 +246,7 @@ describe("Endpoint", () => {
             const rootEndpoint = new Endpoint(0, [ DEVICE.ROOT ], [ basicInformationCluster ], [
                 new Endpoint(1, [ DEVICE.AGGREGATOR ], [
                     new ClusterServer(FixedLabelCluster, {}, {
-                        labelList: [ {label: "bridge", value: "Type A"} ]
+                        labelList: [ { label: "bridge", value: "Type A" } ]
                     }, {}),
                 ])
                 .addEndpoint(11, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
@@ -265,7 +265,7 @@ describe("Endpoint", () => {
                 ]),
                 new Endpoint(2, [ DEVICE.AGGREGATOR ], [
                     new ClusterServer(FixedLabelCluster, {}, {
-                        labelList: [ {label: "bridge", value: "Type B"} ]
+                        labelList: [ { label: "bridge", value: "Type B" } ]
                     }, {}),
                 ])
                 .addEndpoint(21, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
@@ -312,13 +312,13 @@ describe("Endpoint", () => {
             assert.equal(rootEndpoint.endpoints.get(22)?.clusters.has(OnOffCluster.id), true);
 
             const aggregator1PartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 1, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(aggregator1PartsListAttribute?.get(), [new EndpointNumber(11), new EndpointNumber(12)]);
+            assert.deepEqual(aggregator1PartsListAttribute?.getLocal(), [new EndpointNumber(11), new EndpointNumber(12)]);
 
             const aggregator2PartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 2, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(aggregator2PartsListAttribute?.get(), [new EndpointNumber(21), new EndpointNumber(22)]);
+            assert.deepEqual(aggregator2PartsListAttribute?.getLocal(), [new EndpointNumber(21), new EndpointNumber(22)]);
 
             const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
-            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12), new EndpointNumber(2), new EndpointNumber(21), new EndpointNumber(22)]);
+            assert.deepEqual(rootPartsListAttribute?.getLocal(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12), new EndpointNumber(2), new EndpointNumber(21), new EndpointNumber(22)]);
 
             assert.equal(rootEndpoint.attributePaths.length, 91);
             assert.equal(rootEndpoint.commandPaths.length, 12);

--- a/test/matter/interaction/EndpointTest.ts
+++ b/test/matter/interaction/EndpointTest.ts
@@ -175,14 +175,14 @@ describe("Endpoint", () => {
 
             const rootEndpoint = new Endpoint(0, [ DEVICE.ROOT ], [ basicInformationCluster ], [
                 new Endpoint(1, [ DEVICE.AGGREGATOR ], [ ])
-                    .addEndpoint(11, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                    .addEndpoint(11, [ DEVICE.ON_OFF_PLUGIN_UNIT, DEVICE.BRIDGED_DEVICE ], [
                         new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
                             nodeLabel: "Socket 2",
                             reachable: true
                         }, {}),
                         onOffServer
                     ])
-                    .addEndpoint(12, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                    .addEndpoint(12, [ DEVICE.ON_OFF_PLUGIN_UNIT, DEVICE.BRIDGED_DEVICE ], [
                         new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
                             nodeLabel: "Socket 2",
                             reachable: true
@@ -249,14 +249,14 @@ describe("Endpoint", () => {
                         labelList: [ { label: "bridge", value: "Type A" } ]
                     }, {}),
                 ])
-                .addEndpoint(11, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                .addEndpoint(11, [ DEVICE.ON_OFF_PLUGIN_UNIT, DEVICE.BRIDGED_DEVICE ], [
                     new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
                         nodeLabel: "Socket 1-1",
                         reachable: true
                     }, {}),
                     onOffServer
                 ])
-                .addEndpoint(12, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                .addEndpoint(12, [ DEVICE.ON_OFF_PLUGIN_UNIT, DEVICE.BRIDGED_DEVICE ], [
                     new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
                         nodeLabel: "Socket 1-2",
                         reachable: true
@@ -268,14 +268,14 @@ describe("Endpoint", () => {
                         labelList: [ { label: "bridge", value: "Type B" } ]
                     }, {}),
                 ])
-                .addEndpoint(21, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                .addEndpoint(21, [ DEVICE.ON_OFF_PLUGIN_UNIT, DEVICE.BRIDGED_DEVICE ], [
                     new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
                         nodeLabel: "Socket 2-1",
                         reachable: true
                     }, {}),
                     onOffServer
                 ])
-                .addEndpoint(22, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                .addEndpoint(22, [ DEVICE.ON_OFF_PLUGIN_UNIT, DEVICE.BRIDGED_DEVICE ], [
                     new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
                         nodeLabel: "Socket 2-2",
                         reachable: true

--- a/test/matter/interaction/EndpointTest.ts
+++ b/test/matter/interaction/EndpointTest.ts
@@ -1,0 +1,98 @@
+import {ClusterServer, InteractionServer, pathToId} from "../../../src/matter/interaction/InteractionServer";
+import { DEVICE } from "../../../src/matter/common/DeviceTypes";
+import { BasicInformationCluster } from "../../../src/matter/cluster/BasicInformationCluster";
+import { VendorId } from "../../../src/matter/common/VendorId";
+import assert from "assert";
+import {AttributeServer} from "../../../src/matter/cluster/server/AttributeServer";
+import {EndpointNumber} from "../../../src/matter/common/EndpointNumber";
+import {DescriptorCluster} from "../../../src/matter/cluster/DescriptorCluster";
+import {OnOffCluster} from "../../../src/matter/cluster/OnOffCluster";
+import {OnOffClusterHandler} from "../../../src/matter/cluster/server/OnOffServer";
+
+describe("Endpoint", () => {
+
+    context("Endpoint structures", () => {
+        it("only Root endpoint in InteractionServer", () => {
+            const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
+                dataModelRevision: 1,
+                vendorName: "vendor",
+                vendorId: new VendorId(1),
+                productName: "product",
+                productId: 2,
+                nodeLabel: "",
+                hardwareVersion: 0,
+                hardwareVersionString: "",
+                location: "US",
+                localConfigDisabled: false,
+                softwareVersion: 1,
+                softwareVersionString: "v1",
+                capabilityMinima: {
+                    caseSessionsPerFabric: 100,
+                    subscriptionsPerFabric: 100,
+                },
+            }, {});
+
+            const interactionProtocol = new InteractionServer()
+                .addEndpoint(0x00, DEVICE.ROOT, [basicInformationCluster,])
+            ;
+
+            assert.equal(interactionProtocol.endpoints.size, 1);
+            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = interactionProtocol.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(rootPartsListAttribute?.get(), []);
+
+            assert.equal(interactionProtocol.attributePaths.length, 21);
+            assert.equal(interactionProtocol.commandPaths.length, 0);
+        });
+
+        it("Root with Light endpoint in InteractionServer", () => {
+            const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
+                dataModelRevision: 1,
+                vendorName: "vendor",
+                vendorId: new VendorId(1),
+                productName: "product",
+                productId: 2,
+                nodeLabel: "",
+                hardwareVersion: 0,
+                hardwareVersionString: "",
+                location: "US",
+                localConfigDisabled: false,
+                softwareVersion: 1,
+                softwareVersionString: "v1",
+                capabilityMinima: {
+                    caseSessionsPerFabric: 100,
+                    subscriptionsPerFabric: 100,
+                },
+            }, {});
+
+            const onOffServer = new ClusterServer(
+                OnOffCluster,
+                { lightingLevelControl: false },
+                { onOff: false },
+                OnOffClusterHandler()
+            );
+
+            const interactionProtocol = new InteractionServer()
+                .addEndpoint(0x00, DEVICE.ROOT, [basicInformationCluster,])
+                .addEndpoint(0x01, DEVICE.ON_OFF_LIGHT, [ onOffServer ])
+            ;
+
+            assert.equal(interactionProtocol.endpoints.size, 2);
+            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+            assert.equal(interactionProtocol.endpoints.get(1)?.clusters.size, 2);
+            assert.equal(interactionProtocol.endpoints.get(1)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(interactionProtocol.endpoints.get(1)?.clusters.has(OnOffCluster.id), true);
+
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = interactionProtocol.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1)]);
+
+            assert.equal(interactionProtocol.attributePaths.length, 30);
+            assert.equal(interactionProtocol.commandPaths.length, 3);
+        });
+    });
+});

--- a/test/matter/interaction/EndpointTest.ts
+++ b/test/matter/interaction/EndpointTest.ts
@@ -1,18 +1,21 @@
-import {ClusterServer, InteractionServer, pathToId} from "../../../src/matter/interaction/InteractionServer";
+import { ClusterServer, pathToId } from "../../../src/matter/interaction/InteractionServer";
 import { DEVICE } from "../../../src/matter/common/DeviceTypes";
 import { BasicInformationCluster } from "../../../src/matter/cluster/BasicInformationCluster";
 import { VendorId } from "../../../src/matter/common/VendorId";
 import assert from "assert";
-import {AttributeServer} from "../../../src/matter/cluster/server/AttributeServer";
-import {EndpointNumber} from "../../../src/matter/common/EndpointNumber";
-import {DescriptorCluster} from "../../../src/matter/cluster/DescriptorCluster";
-import {OnOffCluster} from "../../../src/matter/cluster/OnOffCluster";
-import {OnOffClusterHandler} from "../../../src/matter/cluster/server/OnOffServer";
+import { AttributeServer } from "../../../src/matter/cluster/server/AttributeServer";
+import { EndpointNumber } from "../../../src/matter/common/EndpointNumber";
+import { DescriptorCluster } from "../../../src/matter/cluster/DescriptorCluster";
+import { OnOffCluster } from "../../../src/matter/cluster/OnOffCluster";
+import { OnOffClusterHandler } from "../../../src/matter/cluster/server/OnOffServer";
+import { Endpoint } from "../../../src/matter/interaction/Endpoint";
+import { BridgedDeviceBasicInformationCluster } from "../../../src/matter/cluster/BridgedDeviceBasicInformationCluster";
+import { FixedLabelCluster } from "../../../src/matter/cluster/LabelCluster";
 
 describe("Endpoint", () => {
 
     context("Endpoint structures", () => {
-        it("only Root endpoint in InteractionServer", () => {
+        it("Simple endpoint", () => {
             const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
                 dataModelRevision: 1,
                 vendorName: "vendor",
@@ -32,23 +35,21 @@ describe("Endpoint", () => {
                 },
             }, {});
 
-            const interactionProtocol = new InteractionServer()
-                .addEndpoint(0x00, DEVICE.ROOT, [basicInformationCluster,])
-            ;
+            const rootEndpoint = new Endpoint(0x00, [ DEVICE.ROOT ], [ basicInformationCluster ]);
 
-            assert.equal(interactionProtocol.endpoints.size, 1);
-            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.size, 2);
-            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
-            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.size, 1);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
 
-            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = interactionProtocol.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
             assert.deepEqual(rootPartsListAttribute?.get(), []);
 
-            assert.equal(interactionProtocol.attributePaths.length, 21);
-            assert.equal(interactionProtocol.commandPaths.length, 0);
+            assert.equal(rootEndpoint.attributePaths.length, 21);
+            assert.equal(rootEndpoint.commandPaths.length, 0);
         });
 
-        it("Root with Light endpoint in InteractionServer", () => {
+        it("One device with Light endpoints", () => {
             const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
                 dataModelRevision: 1,
                 vendorName: "vendor",
@@ -75,24 +76,252 @@ describe("Endpoint", () => {
                 OnOffClusterHandler()
             );
 
-            const interactionProtocol = new InteractionServer()
-                .addEndpoint(0x00, DEVICE.ROOT, [basicInformationCluster,])
-                .addEndpoint(0x01, DEVICE.ON_OFF_LIGHT, [ onOffServer ])
-            ;
+            const rootEndpoint = new Endpoint(0x00, [ DEVICE.ROOT ], [ basicInformationCluster ])
+                .addEndpoint(0x01, [ DEVICE.ON_OFF_LIGHT ], [ onOffServer ]);
 
-            assert.equal(interactionProtocol.endpoints.size, 2);
-            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.size, 2);
-            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
-            assert.equal(interactionProtocol.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
-            assert.equal(interactionProtocol.endpoints.get(1)?.clusters.size, 2);
-            assert.equal(interactionProtocol.endpoints.get(1)?.clusters.has(DescriptorCluster.id), true);
-            assert.equal(interactionProtocol.endpoints.get(1)?.clusters.has(OnOffCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(OnOffCluster.id), true);
 
-            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = interactionProtocol.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
             assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1)]);
 
-            assert.equal(interactionProtocol.attributePaths.length, 30);
-            assert.equal(interactionProtocol.commandPaths.length, 3);
+            assert.equal(rootEndpoint.attributePaths.length, 30);
+            assert.equal(rootEndpoint.commandPaths.length, 3);
+        });
+
+        it("Device Structure with one Light endpoint", () => {
+            const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
+                dataModelRevision: 1,
+                vendorName: "vendor",
+                vendorId: new VendorId(1),
+                productName: "product",
+                productId: 2,
+                nodeLabel: "",
+                hardwareVersion: 0,
+                hardwareVersionString: "",
+                location: "US",
+                localConfigDisabled: false,
+                softwareVersion: 1,
+                softwareVersionString: "v1",
+                capabilityMinima: {
+                    caseSessionsPerFabric: 100,
+                    subscriptionsPerFabric: 100,
+                },
+            }, {});
+
+            const onOffServer = new ClusterServer(
+                OnOffCluster,
+                { lightingLevelControl: false },
+                { onOff: false },
+                OnOffClusterHandler()
+            );
+
+            const rootEndpoint = new Endpoint(0, [ DEVICE.ROOT ], [ basicInformationCluster ], [
+                new Endpoint(1, [ DEVICE.AGGREGATOR ], [ ])
+                    .addEndpoint(11, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [ onOffServer ]),
+            ]);
+
+            assert.equal(rootEndpoint.endpoints.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.size, 1);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(OnOffCluster.id), true);
+
+            const aggregatorPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 1, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(aggregatorPartsListAttribute?.get(), [new EndpointNumber(11)]);
+
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1), new EndpointNumber(11)]);
+
+            assert.equal(rootEndpoint.attributePaths.length, 36);
+            assert.equal(rootEndpoint.commandPaths.length, 3);
+        });
+
+        it("Device Structure with one aggregator and two Light endpoints", () => {
+            const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
+                dataModelRevision: 1,
+                vendorName: "vendor",
+                vendorId: new VendorId(1),
+                productName: "product",
+                productId: 2,
+                nodeLabel: "",
+                hardwareVersion: 0,
+                hardwareVersionString: "",
+                location: "US",
+                localConfigDisabled: false,
+                softwareVersion: 1,
+                softwareVersionString: "v1",
+                capabilityMinima: {
+                    caseSessionsPerFabric: 100,
+                    subscriptionsPerFabric: 100,
+                },
+            }, {});
+
+            const onOffServer = new ClusterServer(
+                OnOffCluster,
+                { lightingLevelControl: false },
+                { onOff: false },
+                OnOffClusterHandler()
+            );
+
+            const rootEndpoint = new Endpoint(0, [ DEVICE.ROOT ], [ basicInformationCluster ], [
+                new Endpoint(1, [ DEVICE.AGGREGATOR ], [ ])
+                    .addEndpoint(11, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                        new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
+                            nodeLabel: "Socket 2",
+                            reachable: true
+                        }, {}),
+                        onOffServer
+                    ])
+                    .addEndpoint(12, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                        new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
+                            nodeLabel: "Socket 2",
+                            reachable: true
+                        }, {}),
+                        onOffServer
+                    ]),
+            ]);
+
+            assert.equal(rootEndpoint.endpoints.size, 4);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.size, 1);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(BridgedDeviceBasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(OnOffCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(BridgedDeviceBasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(OnOffCluster.id), true);
+
+            const aggregatorPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 1, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(aggregatorPartsListAttribute?.get(), [new EndpointNumber(11), new EndpointNumber(12)]);
+
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12)]);
+
+            assert.equal(rootEndpoint.attributePaths.length, 53);
+            assert.equal(rootEndpoint.commandPaths.length, 6);
+        });
+
+        it("Device Structure with two aggregators and two Light endpoints", () => {
+            const basicInformationCluster = new ClusterServer(BasicInformationCluster, {}, {
+                dataModelRevision: 1,
+                vendorName: "vendor",
+                vendorId: new VendorId(1),
+                productName: "product",
+                productId: 2,
+                nodeLabel: "",
+                hardwareVersion: 0,
+                hardwareVersionString: "",
+                location: "US",
+                localConfigDisabled: false,
+                softwareVersion: 1,
+                softwareVersionString: "v1",
+                capabilityMinima: {
+                    caseSessionsPerFabric: 100,
+                    subscriptionsPerFabric: 100,
+                },
+            }, {});
+
+            const onOffServer = new ClusterServer(
+                OnOffCluster,
+                { lightingLevelControl: false },
+                { onOff: false },
+                OnOffClusterHandler()
+            );
+
+            const rootEndpoint = new Endpoint(0, [ DEVICE.ROOT ], [ basicInformationCluster ], [
+                new Endpoint(1, [ DEVICE.AGGREGATOR ], [
+                    new ClusterServer(FixedLabelCluster, {}, {
+                        labelList: [ {label: "bridge", value: "Type A"} ]
+                    }, {}),
+                ])
+                .addEndpoint(11, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                    new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
+                        nodeLabel: "Socket 1-1",
+                        reachable: true
+                    }, {}),
+                    onOffServer
+                ])
+                .addEndpoint(12, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                    new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
+                        nodeLabel: "Socket 1-2",
+                        reachable: true
+                    }, {}),
+                    onOffServer
+                ]),
+                new Endpoint(2, [ DEVICE.AGGREGATOR ], [
+                    new ClusterServer(FixedLabelCluster, {}, {
+                        labelList: [ {label: "bridge", value: "Type B"} ]
+                    }, {}),
+                ])
+                .addEndpoint(21, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                    new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
+                        nodeLabel: "Socket 2-1",
+                        reachable: true
+                    }, {}),
+                    onOffServer
+                ])
+                .addEndpoint(22, [ DEVICE.ON_OFF_LIGHT, DEVICE.BRIDGED_DEVICE ], [
+                    new ClusterServer(BridgedDeviceBasicInformationCluster, {}, {
+                        nodeLabel: "Socket 2-2",
+                        reachable: true
+                    }, {}),
+                    onOffServer
+                ]),
+            ]);
+
+            assert.equal(rootEndpoint.endpoints.size, 7);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(0)?.clusters.has(BasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(FixedLabelCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(2)?.clusters.size, 2);
+            assert.equal(rootEndpoint.endpoints.get(2)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(1)?.clusters.has(FixedLabelCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(BridgedDeviceBasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(11)?.clusters.has(OnOffCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(BridgedDeviceBasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(12)?.clusters.has(OnOffCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(21)?.clusters.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(21)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(21)?.clusters.has(BridgedDeviceBasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(21)?.clusters.has(OnOffCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(22)?.clusters.size, 3);
+            assert.equal(rootEndpoint.endpoints.get(22)?.clusters.has(DescriptorCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(22)?.clusters.has(BridgedDeviceBasicInformationCluster.id), true);
+            assert.equal(rootEndpoint.endpoints.get(22)?.clusters.has(OnOffCluster.id), true);
+
+            const aggregator1PartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 1, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(aggregator1PartsListAttribute?.get(), [new EndpointNumber(11), new EndpointNumber(12)]);
+
+            const aggregator2PartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 2, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(aggregator2PartsListAttribute?.get(), [new EndpointNumber(21), new EndpointNumber(22)]);
+
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = rootEndpoint.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            assert.deepEqual(rootPartsListAttribute?.get(), [new EndpointNumber(1), new EndpointNumber(11), new EndpointNumber(12), new EndpointNumber(2), new EndpointNumber(21), new EndpointNumber(22)]);
+
+            assert.equal(rootEndpoint.attributePaths.length, 91);
+            assert.equal(rootEndpoint.commandPaths.length, 12);
         });
     });
 });


### PR DESCRIPTION
In preparateion to implement Agrregator and Bridged Devcies the Endpoiint structure needs to be more hierarchical to easiely allow structures like shown in Core Specs pg 476 (and following).

All data, and especially the partsList is "bubbled" fropmbottom to top as requitred by the specs.

The next step after the PR ws merged is a second PR that adjusts InteractionServer to use it instead of the current flat logic.

The tests show already how it would "look like" later then basically and cover the "current" simply endpoint case as well as some more complex ones taken from the Bridged Nodes examples.

In this case I also found two "bugs" (OptionalWriteableAttribute - already made also PR to matter.js, and naming for the BridgedDevice cluster).

I also verified that with this code (assuing InteractionServer changes from next step done alteady too) still works for the current simple endpoint usecase on Alexa