### PR TITLE
Request Fabrics dynamically on OperationalCredentialsCluster

### DIFF
--- a/src/matter/MatterDevice.ts
+++ b/src/matter/MatterDevice.ts
@@ -118,7 +118,7 @@ export class MatterDevice {
     completeCommission() {
         return this.fabricManager.completeCommission();
     }
-    
+
     openCommissioningModeWindow(mode: number, discriminator: number) {
         this.broadcasters.forEach(broadcaster => {
             broadcaster.setCommissionMode(mode, this.deviceName, this.deviceType, this.vendorId, this.productId, discriminator);

--- a/src/matter/MatterDevice.ts
+++ b/src/matter/MatterDevice.ts
@@ -88,7 +88,7 @@ export class MatterDevice {
     }
 
     removeFabric(fabricIndex: FabricIndex) {
-        return this.fabricManager.removeFabric(fabricIndex);
+        this.fabricManager.removeFabric(fabricIndex);
     }
 
     initiateExchange(fabric: Fabric, nodeId: NodeId, protocolId: number) {

--- a/src/matter/MatterDevice.ts
+++ b/src/matter/MatterDevice.ts
@@ -88,7 +88,7 @@ export class MatterDevice {
     }
 
     removeFabric(fabricIndex: FabricIndex) {
-        this.fabricManager.removeFabric(fabricIndex);
+        return this.fabricManager.removeFabric(fabricIndex);
     }
 
     initiateExchange(fabric: Fabric, nodeId: NodeId, protocolId: number) {

--- a/src/matter/cluster/server/OperationalCredentialsServer.ts
+++ b/src/matter/cluster/server/OperationalCredentialsServer.ts
@@ -93,7 +93,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         throw new Error("Not implemented");
     },
 
-    updateFabricLabel: async ({ request: {label}, attributes: {fabrics}, session }) => {
+    updateFabricLabel: async ({ request: {label}, session }) => {
         if (!session.isSecure()) throw new Error("updateOperationalCert should be called on a secure session.");
         const secureSession = session as SecureSession<MatterDevice>;
         const fabric = secureSession.getFabric();
@@ -106,7 +106,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         return { status: OperationalCertStatus.Success };
     },
 
-    removeFabric: async ({ request: {fabricIndex}, attributes: {fabrics}, session }) => {
+    removeFabric: async ({ request: {fabricIndex}, session }) => {
         const device = session.getContext();
 
         try {

--- a/src/matter/cluster/server/OperationalCredentialsServer.ts
+++ b/src/matter/cluster/server/OperationalCredentialsServer.ts
@@ -107,14 +107,30 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
             fabricIndex: fabric.fabricIndex,
         })));
 
+        // TODO persist fabrics
+
         return {status: OperationalCertStatus.Success};
     },
 
-    removeFabric: async ({ request: {fabricIndex}, session }) => {
+    removeFabric: async ({ request: {fabricIndex}, attributes: {fabrics}, session }) => {
         const device = session.getContext();
-        device.removeFabric(fabricIndex);
+        if (device.removeFabric(fabricIndex)) {
+            fabrics.setLocal(device.getFabrics().map(fabric => ({
+                fabricId: fabric.fabricId,
+                label: fabric.label,
+                nodeId: fabric.nodeId,
+                rootPublicKey: fabric.rootPublicKey,
+                vendorId: fabric.rootVendorId,
+                fabricIndex: fabric.fabricIndex,
+            })));
 
-        return {status: OperationalCertStatus.Success};
+            // TODO persist fabrics
+            // TODO: depending on cases destroy the secure session and delete all data!
+
+            return { status: OperationalCertStatus.Success };
+        } else {
+            return { status: OperationalCertStatus.InvalidFabricIndex };
+        }
     },
 
     addRootCert: async ({ request: {certificate}, session} ) => {

--- a/src/matter/cluster/server/OperationalCredentialsServer.ts
+++ b/src/matter/cluster/server/OperationalCredentialsServer.ts
@@ -78,7 +78,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         // TODO: create ACL with caseAdminNode
         console.log("addOperationalCert success")
 
-        return {status: OperationalCertStatus.Success, fabricIndex };
+        return { status: OperationalCertStatus.Success, fabricIndex };
     },
 
     getCurrentFabricIndex: session => {

--- a/src/matter/cluster/server/OperationalCredentialsServer.ts
+++ b/src/matter/cluster/server/OperationalCredentialsServer.ts
@@ -114,23 +114,26 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
 
     removeFabric: async ({ request: {fabricIndex}, attributes: {fabrics}, session }) => {
         const device = session.getContext();
-        if (device.removeFabric(fabricIndex)) {
-            fabrics.setLocal(device.getFabrics().map(fabric => ({
-                fabricId: fabric.fabricId,
-                label: fabric.label,
-                nodeId: fabric.nodeId,
-                rootPublicKey: fabric.rootPublicKey,
-                vendorId: fabric.rootVendorId,
-                fabricIndex: fabric.fabricIndex,
-            })));
 
-            // TODO persist fabrics
-            // TODO: depending on cases destroy the secure session and delete all data!
-
-            return { status: OperationalCertStatus.Success };
-        } else {
+        try {
+            device.removeFabric(fabricIndex);
+        } catch {
             return { status: OperationalCertStatus.InvalidFabricIndex };
         }
+
+        fabrics.setLocal(device.getFabrics().map(fabric => ({
+            fabricId: fabric.fabricId,
+            label: fabric.label,
+            nodeId: fabric.nodeId,
+            rootPublicKey: fabric.rootPublicKey,
+            vendorId: fabric.rootVendorId,
+            fabricIndex: fabric.fabricIndex,
+        })));
+
+        // TODO persist fabrics
+        // TODO: depending on cases destroy the secure session and delete all data!
+
+        return { status: OperationalCertStatus.Success };
     },
 
     addRootCert: async ({ request: {certificate}, session} ) => {

--- a/src/matter/fabric/FabricManager.ts
+++ b/src/matter/fabric/FabricManager.ts
@@ -20,9 +20,8 @@ export class FabricManager {
 
     removeFabric(fabricIndex: FabricIndex) {
         const index = this.fabrics.findIndex(fabric => fabric.fabricIndex.index === fabricIndex.index);
-        if (!index) return false;
+        if (index === -1) throw new Error(`Fabric with index ${fabricIndex} cannot be removed because it does not exist.`);
         this.fabrics.splice(index, 1);
-        return true;
     }
 
     getFabrics() {

--- a/src/matter/fabric/FabricManager.ts
+++ b/src/matter/fabric/FabricManager.ts
@@ -19,7 +19,10 @@ export class FabricManager {
     }
 
     removeFabric(fabricIndex: FabricIndex) {
-        this.fabrics.splice(this.fabrics.findIndex(fabric => fabric.fabricIndex.index === fabricIndex.index), 1);
+        const index = this.fabrics.findIndex(fabric => fabric.fabricIndex.index === fabricIndex.index);
+        if (!index) return false;
+        this.fabrics.splice(index, 1);
+        return true;
     }
 
     getFabrics() {
@@ -32,7 +35,7 @@ export class FabricManager {
             if (!candidateDestinationId.equals(destinationId)) continue;
             return fabric;
         }
-        
+
         throw new Error("Fabric cannot be found from destinationId");
     }
 

--- a/src/net/MdnsServer.ts
+++ b/src/net/MdnsServer.ts
@@ -50,7 +50,7 @@ export class MdnsServer {
         if (message === undefined) return; // The message cannot be parsed
         const { transactionId, messageType, queries } = message;
         if (messageType !== MessageType.Query) return;
-        
+
         const answers = message.queries.flatMap(query => this.queryRecords(query, records));
         if (answers.length === 0) return;
 


### PR DESCRIPTION
The fabric is removed, but currently the fabric attribute of the cluster is not updated, sonext request still returns the just deleted fabric and confuses controllers.

It is still missing to "kill the secure session" - or at least the "fabric bound on that session", buit I do not know how, so this is still a good first step.