### PR TITLE
Correctly initialize validator for attribute

### DIFF
--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -42,7 +42,8 @@ export class ClusterServer<ClusterT extends Cluster<any, any, any, any>> {
             featureMap: features,
         };
         for (const name in attributesInitialValues) {
-            const { id, schema, validator } = attributeDefs[name];
+            let { id, schema } = attributeDefs[name];
+            const validator = typeof schema.validate === 'function' ? schema.validate.bind(schema) : undefined;
             const getter = (handlers as any)[`get${capitalize(name)}`];
             if (getter === undefined) {
                 (this.attributes as any)[name] = new AttributeServer(id, name, schema, validator ?? (() => {}), (attributesInitialValues as any)[name]);

--- a/test/matter/interaction/InteractionProtocolTest.ts
+++ b/test/matter/interaction/InteractionProtocolTest.ts
@@ -65,7 +65,7 @@ describe("InteractionProtocol", () => {
                         productId: 2,
                         nodeLabel: "",
                         hardwareVersion: 0,
-                        hardwareVersionString: "",
+                        hardwareVersionString: "0",
                         location: "US",
                         localConfigDisabled: false,
                         softwareVersion: 1,


### PR DESCRIPTION
There was no "validator" property on the AttributeServer, but the validate method is on the schema object.

See first test run of this PR ... the validator is used now again ... second rund (after fixing tests) will fix it