### PR TITLE
Add isWritable flag on AttributeServer

### DIFF
--- a/src/matter/cluster/server/AttributeServer.ts
+++ b/src/matter/cluster/server/AttributeServer.ts
@@ -20,6 +20,7 @@ export class AttributeServer<T> {
         readonly name: string,
         readonly schema: TlvSchema<T>,
         private readonly validator: (value: T, name: string) => void,
+        readonly isWritable: boolean,
         defaultValue: T,
     ) {
         validator(defaultValue, name);
@@ -81,10 +82,11 @@ export class AttributeGetterServer<T> extends AttributeServer<T> {
         name: string,
         schema: TlvSchema<T>,
         validator: (value: T, name: string) => void,
+        isWritable: boolean,
         defaultValue: T,
         readonly getter: (session?: Session<MatterDevice>) => T,
     ) {
-        super(id, name, schema, validator, defaultValue);
+        super(id, name, schema, validator, isWritable, defaultValue);
     }
 
     setLocal(value: T) {

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -268,7 +268,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                     && (clusterId === undefined || clusterId === path.clusterId)
                     && (id === undefined || id === path.id))
                     .forEach(path => {
-                        const attribute = this.attributes.get(attributePathToId(path)) as AttributeServer<any>;
+                        const attribute = this.attributes.get(pathToId(path)) as AttributeServer<any>;
                         if (attribute === undefined) return;
                         if (onlyWritable && !attribute.isWritable) return;
                         result.push({ path, attribute })

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -42,12 +42,12 @@ export class ClusterServer<ClusterT extends Cluster<any, any, any, any>> {
             featureMap: features,
         };
         for (const name in attributesInitialValues) {
-            const { id, schema, validator } = attributeDefs[name];
+            const { id, schema, writable } = attributeDefs[name];
             const getter = (handlers as any)[`get${capitalize(name)}`];
             if (getter === undefined) {
-                (this.attributes as any)[name] = new AttributeServer(id, name, schema, validator ?? (() => {}), (attributesInitialValues as any)[name]);
+                (this.attributes as any)[name] = new AttributeServer(id, name, schema, validator ?? (() => {}), writable, (attributesInitialValues as any)[name]);
             } else {
-                (this.attributes as any)[name] = new AttributeGetterServer(id, name, schema, validator ?? (() => {}), (attributesInitialValues as any)[name], getter);
+                (this.attributes as any)[name] = new AttributeGetterServer(id, name, schema, validator ?? (() => {}), writable, (attributesInitialValues as any)[name], getter);
             }
         }
 

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -42,7 +42,7 @@ export class ClusterServer<ClusterT extends Cluster<any, any, any, any>> {
             featureMap: features,
         };
         for (const name in attributesInitialValues) {
-            const { id, schema, writable } = attributeDefs[name];
+            const { id, schema, validaor, writable } = attributeDefs[name];
             const getter = (handlers as any)[`get${capitalize(name)}`];
             if (getter === undefined) {
                 (this.attributes as any)[name] = new AttributeServer(id, name, schema, validator ?? (() => {}), writable, (attributesInitialValues as any)[name]);

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -42,7 +42,7 @@ export class ClusterServer<ClusterT extends Cluster<any, any, any, any>> {
             featureMap: features,
         };
         for (const name in attributesInitialValues) {
-            const { id, schema, validaor, writable } = attributeDefs[name];
+            const { id, schema, validator, writable } = attributeDefs[name];
             const getter = (handlers as any)[`get${capitalize(name)}`];
             if (getter === undefined) {
                 (this.attributes as any)[name] = new AttributeServer(id, name, schema, validator ?? (() => {}), writable, (attributesInitialValues as any)[name]);


### PR DESCRIPTION
This PR adds a isWritable flag on the AttributeServer and allows to filter for only writable attributes on getAttributes