### PR TITLE
Separate Path types for attributes and commands

### DIFF
--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -80,7 +80,7 @@ export const TlvAttributeReportPath = TlvList({
     endpointId: TlvField(2, TlvUInt16), // TODO: could be optional, handling then defined by enableTagCompression
     clusterId: TlvField(3, TlvUInt32),
     attributeId: TlvField(4, TlvUInt32),
-    listIndex: TlvOptionalField(5,  TlvNullable(TlvUInt16)),
+    listIndex: TlvOptionalField(5, TlvNullable(TlvUInt16)),
 });
 
 export const TlvAttributeReportValue = TlvObject({

--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -5,7 +5,22 @@
  */
 
 import { TlvNodeId } from "../common/NodeId";
-import { MatterCoreSpecificationV1_0, TlvAny, TlvArray, TlvBoolean, TlvEnum, TlvField, TlvList, TlvObject, TlvOptionalField, TlvUInt16, TlvUInt32, TlvUInt64, TlvUInt8 } from "@project-chip/matter.js";
+import {
+    MatterCoreSpecificationV1_0,
+    TlvAny,
+    TlvArray,
+    TlvBoolean,
+    TlvEnum,
+    TlvField,
+    TlvList,
+    TlvNullable,
+    TlvObject,
+    TlvOptionalField,
+    TlvUInt16,
+    TlvUInt32,
+    TlvUInt64,
+    TlvUInt8
+} from "@project-chip/matter.js";
 
 /**
  * @see {@link MatterCoreSpecificationV1_0}, section 8.10
@@ -44,10 +59,13 @@ export const TlvStatusResponse = TlvObject({
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 
-const TlvAttributePath = TlvList({
+export const TlvAttributePath = TlvList({
+    enableTagCompression: TlvOptionalField(0, TlvBoolean),
+    nodeId: TlvOptionalField(1, TlvNodeId),
     endpointId: TlvOptionalField(2, TlvUInt16),
     clusterId: TlvOptionalField(3, TlvUInt32),
-    id: TlvOptionalField(4, TlvUInt32),
+    attributeId: TlvOptionalField(4, TlvUInt32),
+    listIndex: TlvOptionalField(5,  TlvNullable(TlvUInt16)),
 });
 
 export const TlvReadRequest = TlvObject({
@@ -56,16 +74,23 @@ export const TlvReadRequest = TlvObject({
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 
+export const TlvAttributeReportPath = TlvList({
+    enableTagCompression: TlvOptionalField(0, TlvBoolean),
+    nodeId: TlvOptionalField(1, TlvNodeId),
+    endpointId: TlvField(2, TlvUInt16), // TODO: could be optional, handling then defined by enableTagCompression
+    clusterId: TlvField(3, TlvUInt32),
+    attributeId: TlvField(4, TlvUInt32),
+    listIndex: TlvOptionalField(5,  TlvNullable(TlvUInt16)),
+});
+
+export const TlvAttributeReportValue = TlvObject({
+    version: TlvField(0, TlvUInt32),
+    path: TlvField(1, TlvAttributeReportPath),
+    value: TlvField(2, TlvAny),
+});
+
 export const TlvAttributeReport = TlvObject({
-    value: TlvField(1, TlvObject({
-        version: TlvField(0, TlvUInt32),
-        path: TlvField(1, TlvList({
-            endpointId: TlvField(2, TlvUInt16),
-            clusterId: TlvField(3, TlvUInt32),
-            id: TlvField(4, TlvUInt32),
-        })),
-        value: TlvField(2, TlvAny),
-    })),
+    value: TlvField(1, TlvAttributeReportValue),
 });
 
 export const TlvDataReport = TlvObject({
@@ -109,15 +134,17 @@ export const TlvSubscribeResponse = TlvObject({
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 
+export const TlvCommandPath = TlvList({
+    endpointId: TlvField(0, TlvUInt16),
+    clusterId: TlvField(1, TlvUInt32),
+    commandId: TlvField(2, TlvUInt32),
+});
+
 export const TlvInvokeRequest = TlvObject({
     suppressResponse: TlvField(0,  TlvBoolean),
     timedRequest: TlvField(1,  TlvBoolean),
     invokes: TlvField(2, TlvArray(TlvObject({
-        path: TlvField(0, TlvList({
-            endpointId: TlvField(0, TlvUInt16),
-            clusterId: TlvField(1, TlvUInt32),
-            id: TlvField(2, TlvUInt32),
-        })),
+        path: TlvField(0, TlvCommandPath),
         args: TlvField(1, TlvAny),
     }))),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
@@ -127,19 +154,11 @@ export const TlvInvokeResponse = TlvObject({
     suppressResponse: TlvField(0,  TlvBoolean),
     responses: TlvField(1, TlvArray(TlvObject({
         response: TlvOptionalField(0, TlvObject({
-            path: TlvField(0, TlvList({
-                endpointId: TlvField(0, TlvUInt16),
-                clusterId: TlvField(1, TlvUInt32),
-                id: TlvField(2, TlvUInt32),
-            })),
+            path: TlvField(0, TlvCommandPath),
             response: TlvField(1, TlvAny),
         })),
         result: TlvOptionalField(1, TlvObject({
-            path: TlvField(0, TlvList({
-                endpointId: TlvField(0, TlvUInt16),
-                clusterId: TlvField(1, TlvUInt32),
-                id: TlvField(2, TlvUInt32),
-            })),
+            path: TlvField(0, TlvCommandPath),
             result: TlvField(1, TlvObject({
                 code: TlvField(0, TlvUInt16),
             })),

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -61,19 +61,29 @@ export class ClusterServer<ClusterT extends Cluster<any, any, any, any>> {
     }
 }
 
-export interface Path {
+export interface CommandPath {
     endpointId: number,
     clusterId: number,
-    id: number,
+    commandId: number,
+}
+
+export interface AttributePath {
+    endpointId: number,
+    clusterId: number,
+    attributeId: number,
 }
 
 export interface AttributeWithPath {
-    path: Path,
+    path: AttributePath,
     attribute: AttributeServer<any>,
 }
 
-export function pathToId({endpointId, clusterId, id}: Path) {
-    return `${endpointId}/${clusterId}/${id}`;
+export function commandPathToId({endpointId, clusterId, commandId}: CommandPath) {
+    return `${endpointId}/${clusterId}/${commandId}`;
+}
+
+export function attributePathToId({endpointId, clusterId, attributeId}: Partial<AttributePath>) {
+    return `${endpointId}/${clusterId}/${attributeId}`;
 }
 
 function toHex(value: number | undefined) {
@@ -85,9 +95,9 @@ const logger = Logger.get("InteractionProtocol");
 export class InteractionServer implements ProtocolHandler<MatterDevice> {
     private readonly endpoints = new Map<number, { name: string, code: number, clusters: Map<number, ClusterServer<any>> }>();
     private readonly attributes = new Map<string, AttributeServer<any>>();
-    private readonly attributePaths = new Array<Path>();
+    private readonly attributePaths = new Array<AttributePath>();
     private readonly commands = new Map<string, CommandServer<any, any>>();
-    private readonly commandPaths = new Array<Path>();
+    private readonly commandPaths = new Array<CommandPath>();
 
     constructor() {}
 
@@ -113,22 +123,22 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             // Add attributes
             for (const name in attributes) {
                 const attribute = attributes[name];
-                const path = { endpointId, clusterId, id: attribute.id };
-                this.attributes.set(pathToId(path), attribute);
+                const path = { endpointId, clusterId, attributeId: attribute.id };
+                this.attributes.set(attributePathToId(path), attribute);
                 this.attributePaths.push(path);
             }
 
             // Add commands
             commands.forEach(command => {
-                const path = { endpointId, clusterId, id: command.invokeId };
-                this.commands.set(pathToId(path), command);
+                const path = { endpointId, clusterId, commandId: command.invokeId };
+                this.commands.set(commandPathToId(path), command);
                 this.commandPaths.push(path);
             });
         });
 
         // Add part list if the endpoint is not root
         if (endpointId !== 0) {
-            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = this.attributes.get(pathToId({endpointId: 0, clusterId: DescriptorCluster.id, id: DescriptorCluster.attributes.partsList.id}));
+            const rootPartsListAttribute: AttributeServer<EndpointNumber[]> | undefined = this.attributes.get(attributePathToId({endpointId: 0, clusterId: DescriptorCluster.id, attributeId: DescriptorCluster.attributes.partsList.id}));
             if (rootPartsListAttribute === undefined) throw new Error("The root endpoint should be added first!");
             rootPartsListAttribute.setLocal([...rootPartsListAttribute.getLocal(), new EndpointNumber(endpointId)]);
         }
@@ -196,12 +206,12 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
     }
 
     async handleInvokeRequest(exchange: MessageExchange<MatterDevice>, {invokes}: InvokeRequest): Promise<InvokeResponse> {
-        logger.debug(`Received invoke request from ${exchange.channel.getName()}: ${invokes.map(({path: {endpointId, clusterId, id}}) => `${toHex(endpointId)}/${toHex(clusterId)}/${toHex(id)}`).join(", ")}`);
+        logger.debug(`Received invoke request from ${exchange.channel.getName()}: ${invokes.map(({ path: {endpointId, clusterId, commandId }}) => `${toHex(endpointId)}/${toHex(clusterId)}/${toHex(commandId)}`).join(", ")}`);
 
-        const results = new Array<{path: Path, code: ResultCode, response: TlvStream, responseId: number }>();
+        const results = new Array<{path: CommandPath, code: ResultCode, response: TlvStream, responseId: number }>();
 
         await Promise.all(invokes.map(async ({ path, args }) => {
-            const command = this.commands.get(pathToId(path));
+            const command = this.commands.get(commandPathToId(path));
             if (command === undefined) return;
             const result = await command.invoke(exchange.session, args);
             results.push({ ...result, path });
@@ -214,7 +224,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
                 if (response.length === 0) {
                     return { result: { path, result: { code }} };
                 } else {
-                    return { response: { path: { ...path, id: responseId }, response} };
+                    return { response: { path: { ...path, commandId: responseId }, response} };
                 }
             }),
         };
@@ -225,50 +235,50 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
         // TODO: implement this
     }
 
-    private resolveAttributeName({ endpointId, clusterId, id }: Partial<Path>) {
+    private resolveAttributeName({ endpointId, clusterId, attributeId }: Partial<AttributePath>) {
         if (endpointId === undefined) {
-            return `*/${toHex(clusterId)}/${toHex(id)}`;
+            return `*/${toHex(clusterId)}/${toHex(attributeId)}`;
         }
         const endpoint = this.endpoints.get(endpointId);
         if (endpoint === undefined) {
-            return `unknown(${toHex(endpointId)})/${toHex(clusterId)}/${toHex(id)}`;
+            return `unknown(${toHex(endpointId)})/${toHex(clusterId)}/${toHex(attributeId)}`;
         }
         const endpointName = `${endpoint.name}(${toHex(endpointId)})`;
 
         if (clusterId === undefined) {
-            return `${endpointName}/*/${toHex(id)}`;
+            return `${endpointName}/*/${toHex(attributeId)}`;
         }
         const cluster = endpoint.clusters.get(clusterId);
         if (cluster === undefined) {
-            return `${endpointName}/unkown(${toHex(clusterId)})/${toHex(id)}`;
+            return `${endpointName}/unknown(${toHex(clusterId)})/${toHex(attributeId)}`;
         }
         const clusterName = `${cluster.name}(${toHex(clusterId)})`;
 
-        if (id === undefined) {
+        if (attributeId === undefined) {
             return `${endpointName}/${clusterName}/*`;
         }
-        const attribute = this.attributes.get(pathToId({ endpointId, clusterId, id }));
-        const attributeName = `${attribute?.name ?? "unknown"}(${toHex(id)})`;
+        const attribute = this.attributes.get(attributePathToId({ endpointId, clusterId, attributeId }));
+        const attributeName = `${attribute?.name ?? "unknown"}(${toHex(attributeId)})`;
         return `${endpointName}/${clusterName}/${attributeName}`;
     }
 
-    private getAttributes(filters: Partial<Path>[] ): AttributeWithPath[] {
+    private getAttributes(filters: Partial<AttributePath>[] ): AttributeWithPath[] {
         const result = new Array<AttributeWithPath>();
 
-        filters.forEach(({ endpointId, clusterId, id }) => {
-            if (endpointId !== undefined && clusterId !== undefined && id !== undefined) {
-                const path = { endpointId, clusterId, id };
-                const attribute = this.attributes.get(pathToId(path));
+        filters.forEach(({ endpointId, clusterId, attributeId }) => {
+            if (endpointId !== undefined && clusterId !== undefined && attributeId !== undefined) {
+                const path = { endpointId, clusterId, attributeId };
+                const attribute = this.attributes.get(attributePathToId(path));
                 if (attribute === undefined) return;
                 result.push({ path, attribute });
             } else {
                 this.attributePaths.filter(path =>
                     (endpointId === undefined || endpointId === path.endpointId)
                     && (clusterId === undefined || clusterId === path.clusterId)
-                    && (id === undefined || id === path.id))
-                    .forEach(path => result.push({ path, attribute: this.attributes.get(pathToId(path)) as AttributeServer<any> }));
+                    && (attributeId === undefined || attributeId === path.attributeId))
+                    .forEach(path => result.push({ path, attribute: this.attributes.get(attributePathToId(path)) as AttributeServer<any> }));
             }
-        })
+        });
 
         return result;
     }

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -263,7 +263,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
         return `${endpointName}/${clusterName}/${attributeName}`;
     }
 
-    private getAttributes(filters: Partial<Path>[], onlyWritable: boolean = false): AttributeWithPath[] {
+    private getAttributes(filters: Partial<AttributePath>[], onlyWritable: boolean = false): AttributeWithPath[] {
         const result = new Array<AttributeWithPath>();
 
         filters.forEach(({ endpointId, clusterId, attributeId }) => {

--- a/src/matter/interaction/SubscriptionHandler.ts
+++ b/src/matter/interaction/SubscriptionHandler.ts
@@ -7,13 +7,13 @@
 import { MatterDevice } from "../MatterDevice";
 import { InteractionServerMessenger } from "./InteractionMessenger";
 import { Fabric } from "../fabric/Fabric";
-import { AttributeWithPath, Path, INTERACTION_PROTOCOL_ID } from "./InteractionServer";
+import { AttributeWithPath, AttributePath, INTERACTION_PROTOCOL_ID } from "./InteractionServer";
 import { Time, Timer } from "../../time/Time";
 import { NodeId } from "../common/NodeId";
 import { TlvSchema } from "@project-chip/matter.js";
 
 interface PathValueVersion<T> {
-    path: Path,
+    path: AttributePath,
     schema: TlvSchema<T>,
     valueVersion: { value: T, version: number },
 }

--- a/test/matter/interaction/InteractionProtocolTest.ts
+++ b/test/matter/interaction/InteractionProtocolTest.ts
@@ -22,8 +22,8 @@ const READ_REQUEST: ReadRequest = {
     interactionModelRevision: 1,
     isFabricFiltered: true,
     attributes: [
-        { endpointId: 0, clusterId: 0x28, id: 2},
-        { endpointId: 0, clusterId: 0x28, id: 4},
+        { endpointId: 0, clusterId: 0x28, attributeId: 2},
+        { endpointId: 0, clusterId: 0x28, attributeId: 4},
     ],
 };
 
@@ -34,7 +34,7 @@ const READ_RESPONSE: DataReport = {
             path: {
                 endpointId: 0,
                 clusterId: 0x28,
-                id: 2,
+                attributeId: 2,
             },
             value: TlvUInt8.encodeTlv(1),
             version: 0,
@@ -43,7 +43,7 @@ const READ_RESPONSE: DataReport = {
             path: {
                 endpointId: 0,
                 clusterId: 0x28,
-                id: 4,
+                attributeId: 4,
             },
             value: TlvUInt8.encodeTlv(2),
             version: 0,


### PR DESCRIPTION
While woring on WriteRequestsand also other topics I had issues because the commandPath and AttributePaths are using the same txpe but in fact are not "the same structure" in details ... Thats why I splitted these up