### PR TITLE
Fixes to pair controller against chip-tool lighting app

### DIFF
--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -35,7 +35,7 @@ class Controller {
         const port = getIntParameter("port") ?? 5540;
         const discriminator = getIntParameter("discriminator") ?? 3840;
         const setupPin = getIntParameter("pin") ?? 20202021;
-        const client = await MatterController.create(await MdnsScanner.create(), await UdpInterface.create(5540, "udp6"));
+        const client = await MatterController.create(await MdnsScanner.create(), await UdpInterface.create(5540, "udp4"), await UdpInterface.create(5540, "udp6"));
         try {
             await client.commission(ip, port, discriminator, setupPin);
         } finally {

--- a/src/matter/MatterController.ts
+++ b/src/matter/MatterController.ts
@@ -26,17 +26,18 @@ import { NodeId } from "./common/NodeId";
 import { VendorId } from "./common/VendorId";
 import { ByteArray } from "@project-chip/matter.js";
 import { FabricIndex } from "./common/FabricIndex";
+import { isIPv6 } from "../util/Ip";
 
 requireMinNodeVersion(16);
 
 const FABRIC_INDEX = new FabricIndex(1);
 const FABRIC_ID = BigInt(1);
-const CONTROLLER_NODE_ID = new NodeId(BigInt(0));
+const CONTROLLER_NODE_ID = new NodeId(BigInt(1));
 const ADMIN_VENDOR_ID = new VendorId(752);
 const logger = Logger.get("MatterController");
 
 export class MatterController {
-    public static async create(scanner: Scanner, netInterface: NetInterface) {
+    public static async create(scanner: Scanner, netInterfaceIpv4: NetInterface, netInterfaceIpv6: NetInterface) {
         const certificateManager = new RootCertificateManager();
         const ipkValue = Crypto.getRandomData(16);
         const fabricBuilder = new FabricBuilder(FABRIC_INDEX)
@@ -46,7 +47,7 @@ export class MatterController {
             .setRootVendorId(ADMIN_VENDOR_ID);
         fabricBuilder.setOperationalCert(certificateManager.generateNoc(fabricBuilder.getPublicKey(), FABRIC_ID, CONTROLLER_NODE_ID));
         const fabric = await fabricBuilder.build();
-        return new MatterController(scanner, netInterface, certificateManager, fabric);
+        return new MatterController(scanner, netInterfaceIpv4, netInterfaceIpv6, certificateManager, fabric);
     }
 
     private readonly sessionManager = new SessionManager(this);
@@ -57,15 +58,18 @@ export class MatterController {
 
     constructor(
         private readonly scanner: Scanner,
-        private readonly netInterface: NetInterface,
+        private readonly netInterfaceIpv4: NetInterface,
+        private readonly netInterfaceIpv6: NetInterface,
         private readonly certificateManager: RootCertificateManager,
         private readonly fabric: Fabric,
     ) {
-        this.exchangeManager.addNetInterface(netInterface);
+        this.exchangeManager.addNetInterface(netInterfaceIpv4);
+        this.exchangeManager.addNetInterface(netInterfaceIpv6);
     }
 
     async commission(commissionAddress: string, commissionPort: number, discriminator: number, setupPin: number) {
-        const paseChannel = await this.netInterface.openChannel(commissionAddress, commissionPort);
+        const paseInterface = isIPv6(commissionAddress) ? this.netInterfaceIpv6 : this.netInterfaceIpv4;
+        const paseChannel = await paseInterface.openChannel(commissionAddress, commissionPort);
 
         // Do PASE paring
         const paseUnsecureMessageChannel = new MessageChannel(paseChannel, this.sessionManager.getUnsecureSession());
@@ -114,7 +118,8 @@ export class MatterController {
         const { ip: operationalIp, port: operationalPort } = scanResult;
 
         // Do CASE pairing
-        const operationalChannel = await this.netInterface.openChannel(operationalIp, operationalPort);
+        const operationalInterface = isIPv6(operationalIp) ? this.netInterfaceIpv6 : this.netInterfaceIpv4;
+        const operationalChannel = await operationalInterface.openChannel(operationalIp, operationalPort);
         const operationalUnsecureMessageExchange = new MessageChannel(operationalChannel, this.sessionManager.getUnsecureSession());
         const operationalSecureSession = await this.caseClient.pair(this, this.exchangeManager.initiateExchangeWithChannel(operationalUnsecureMessageExchange, SECURE_CHANNEL_PROTOCOL_ID), this.fabric, peerNodeId);
         this.channelManager.setChannel(this.fabric, peerNodeId, new MessageChannel(operationalChannel, operationalSecureSession));
@@ -123,6 +128,7 @@ export class MatterController {
         // Complete the commission
         generalCommissioningClusterClient = ClusterClient(interactionClient, 0, GeneralCommissioningCluster);
         this.ensureSuccess(await generalCommissioningClusterClient.commissioningComplete({}));
+        return peerNodeId;
     }
 
     async connect(nodeId: NodeId) {
@@ -178,7 +184,7 @@ class RootCertificateManager {
             signatureAlgorithm: 1 /* EcdsaWithSHA256 */ ,
             publicKeyAlgorithm: 1 /* EC */,
             ellipticCurveIdentifier: 1 /* P256v1 */,
-            issuer: { },
+            issuer: { issuerRcacId: this.rootCertId },
             notBefore: jsToMatterDate(now, -1),
             notAfter: jsToMatterDate(now, 10),
             subject: { rcacId: this.rootCertId },

--- a/src/matter/common/ExchangeManager.ts
+++ b/src/matter/common/ExchangeManager.ts
@@ -92,7 +92,7 @@ export class ExchangeManager<ContextT> {
         const exchangeIndex = message.payloadHeader.isInitiatorMessage ? message.payloadHeader.exchangeId : (message.payloadHeader.exchangeId | 0x10000);
         const exchange = this.exchanges.get(exchangeIndex);
         if (exchange !== undefined) {
-            exchange.onMessageReceived(message);
+            await exchange.onMessageReceived(message);
         } else {
             const exchange = await MessageExchange.fromInitialMessage(this.channelManager.getOrCreateChannel(channel, session), this.messageCounter, message, () => this.exchanges.delete(exchangeIndex));
             this.exchanges.set(exchangeIndex, exchange);

--- a/src/matter/common/NodeId.ts
+++ b/src/matter/common/NodeId.ts
@@ -5,11 +5,15 @@
  */
 
 import { DataWriter, Endian, MatterCoreSpecificationV1_0, TlvUInt64, TlvWrapper } from "@project-chip/matter.js";
+import crypto from "crypto";
+
+const OPERATIONAL_NODE_MIN = BigInt('0x0000000000000001');
+const OPERATIONAL_NODE_MAX = BigInt('0xFFFFFFEFFFFFFFFF');
 
 /**
  * A Node Identifier (Node ID) is a 64-bit number that uniquely identifies an individual Node or a
  * group of Nodes on a Fabric.
- * 
+ *
  * @see {@link MatterCoreSpecificationV1_0} § 2.5.5
  */
 export class NodeId {
@@ -21,6 +25,22 @@ export class NodeId {
         const writer = new DataWriter(Endian.Big);
         writer.writeUInt64(this.id);
         return writer.toByteArray().toHex().toUpperCase();
+    }
+
+    static getRandomOperationalNodeId() {
+        while (true) {
+            const randomBigInt = BigInt('0x' + crypto.randomBytes(8).toString('hex'));
+            if (randomBigInt >= OPERATIONAL_NODE_MIN && randomBigInt <= OPERATIONAL_NODE_MAX) {
+                return new NodeId(randomBigInt);
+            }
+        }
+    }
+
+    static getGroupNodeId(groupId: number) {
+        if (groupId < 0 || groupId > 0xFFFF) {
+            throw new Error(`Invalid group ID: ${groupId}`);
+        }
+        return new NodeId(BigInt('0xFFFFFFFFFFFF' + groupId.toString(16).padStart(4, "0")));
     }
 }
 

--- a/src/matter/interaction/InteractionClient.ts
+++ b/src/matter/interaction/InteractionClient.ts
@@ -24,10 +24,10 @@ export function ClusterClient<CommandT extends Commands, AttributeT extends Attr
     // Add accessors
     for (const attributeName in attributes) {
         const attribute = attributes[attributeName];
-        const captilizedAttributeName = capitalize(attributeName);
-        result[`get${captilizedAttributeName}`] = async () => interactionClient.get(endpointId, clusterId, attribute);
-        result[`set${captilizedAttributeName}`] = async <T,>(value: T) => interactionClient.set<T>(endpointId, clusterId, attribute, value);
-        result[`subscribe${captilizedAttributeName}`] = async <T,>(listener: (value: T, version: number) => void, minIntervalS: number, maxIntervalS: number) => interactionClient.subscribe(endpointId, clusterId, attribute, listener, minIntervalS, maxIntervalS);
+        const capitalizedAttributeName = capitalize(attributeName);
+        result[`get${capitalizedAttributeName}`] = async () => interactionClient.get(endpointId, clusterId, attribute);
+        result[`set${capitalizedAttributeName}`] = async <T,>(value: T) => interactionClient.set<T>(endpointId, clusterId, attribute, value);
+        result[`subscribe${capitalizedAttributeName}`] = async <T,>(listener: (value: T, version: number) => void, minIntervalS: number, maxIntervalS: number) => interactionClient.subscribe(endpointId, clusterId, attribute, listener, minIntervalS, maxIntervalS);
     }
 
     // Add command calls
@@ -108,15 +108,15 @@ export class InteractionClient {
         clusterId: number,
         { id, schema, default: conformanceValue }: A,
         listener: (value: AttributeJsType<A>, version: number) => void,
-        minIntervalFloorSeconds: number,  
-        maxIntervalCeilingSeconds: number, 
+        minIntervalFloorSeconds: number,
+        maxIntervalCeilingSeconds: number,
     ): Promise<void> {
         return this.withMessenger<void>(async messenger => {
             const { subscriptionId } = await messenger.sendSubscribeRequest({
                 attributeRequests: [ {endpointId , clusterId, id} ],
                 keepSubscriptions: true,
-                minIntervalFloorSeconds,  
-                maxIntervalCeilingSeconds,              
+                minIntervalFloorSeconds,
+                maxIntervalCeilingSeconds,
                 isFabricFiltered: true,
             });
 

--- a/src/matter/session/SessionManager.ts
+++ b/src/matter/session/SessionManager.ts
@@ -40,7 +40,7 @@ export class SessionManager<ContextT> {
         const session = await SecureSession.create(this.context, sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, salt, isInitiator, isResumption, idleRetransTimeoutMs, activeRetransTimeoutMs);
         this.sessions.set(sessionId, session);
 
-        // TODO: close previous secure channel for 
+        // TODO: close previous secure channel for
         return session;
     }
 
@@ -66,7 +66,6 @@ export class SessionManager<ContextT> {
             return secureSession.getFabric() === fabric && secureSession.getPeerNodeId() === nodeId;
         });
     }
-
 
     getUnsecureSession() {
         return this.unsecureSession;

--- a/src/matter/session/UnsecureSession.ts
+++ b/src/matter/session/UnsecureSession.ts
@@ -9,8 +9,11 @@ import { Fabric } from "../fabric/Fabric";
 import { DEFAULT_ACTIVE_RETRANSMISSION_TIMEOUT_MS, DEFAULT_IDLE_RETRANSMISSION_TIMEOUT_MS, DEFAULT_RETRANSMISSION_RETRIES, Session } from "./Session";
 import { UNICAST_UNSECURE_SESSION_ID } from "./SessionManager";
 import { ByteArray } from "@project-chip/matter.js";
+import { NodeId } from "../common/NodeId";
 
 export class UnsecureSession<T> implements Session<T> {
+    private readonly initiatorNodeId = NodeId.getRandomOperationalNodeId();
+
     constructor(
         private readonly context: T,
     ) {}
@@ -60,7 +63,7 @@ export class UnsecureSession<T> implements Session<T> {
     }
 
     getNodeId() {
-        return undefined;
+        return this.initiatorNodeId;
     }
 
     getPeerNodeId() {

--- a/src/util/Ip.ts
+++ b/src/util/Ip.ts
@@ -10,6 +10,10 @@ export function isIPv4(ip: string) {
     return ip.includes(".")
 }
 
+export function isIPv6(ip: string) {
+    return ip.includes(":")
+}
+
 export function iPv4ToNumber(ip: string) {
     const dataView = new ByteArray(4).getDataView();
     const ipParts = ip.split(".");


### PR DESCRIPTION
This PR makes sure to successfully allow node-matter as controller to pair against chip-tool apps. I needed to change the following topics:

* The Controller Node ID must not be 0 :-)
* The root certificate missed one entry
* Unsecure sessions should get random Ephemeral Initiator Node ID assigned if we start the session, enhanced NodeId for this to create a NodeId out of the defined region.
* I enhanced MatterController to have both ipv4 and ipv6 interfaces and choose based on the provided/discovered IP because else it would get problematic because discovery during commissioning process could find a IPv6 too