### PR TITLE
Forward the Message to invoke command handler

### DIFF
--- a/src/matter/cluster/server/CommandServer.ts
+++ b/src/matter/cluster/server/CommandServer.ts
@@ -7,6 +7,7 @@
 import { MatterDevice } from "../../MatterDevice";
 import { Session } from "../../session/Session";
 import { TlvSchema, TlvStream } from "@project-chip/matter.js";
+import { PacketHeader } from "../../../codec/MessageCodec";
 
 export const enum ResultCode {
     Success = 0x00,
@@ -19,12 +20,12 @@ export class CommandServer<RequestT, ResponseT> {
         readonly name: string,
         protected readonly requestSchema: TlvSchema<RequestT>,
         protected readonly responseSchema: TlvSchema<ResponseT>,
-        protected readonly handler: (request: RequestT, session: Session<MatterDevice>) => Promise<ResponseT> | ResponseT,
+        protected readonly handler: (request: RequestT, session: Session<MatterDevice>, packetHeader: PacketHeader) => Promise<ResponseT> | ResponseT,
     ) {}
 
-    async invoke(session: Session<MatterDevice>, args: TlvStream): Promise<{ code: ResultCode, responseId: number, response: TlvStream }> {
+    async invoke(session: Session<MatterDevice>, args: TlvStream, packetHeader: PacketHeader): Promise<{ code: ResultCode, responseId: number, response: TlvStream }> {
         const request = this.requestSchema.decodeTlv(args);
-        const response = await this.handler(request, session);
+        const response = await this.handler(request, session, packetHeader);
         return { code: ResultCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
     }
 }

--- a/src/matter/cluster/server/CommandServer.ts
+++ b/src/matter/cluster/server/CommandServer.ts
@@ -7,7 +7,7 @@
 import { MatterDevice } from "../../MatterDevice";
 import { Session } from "../../session/Session";
 import { TlvSchema, TlvStream } from "@project-chip/matter.js";
-import { PacketHeader } from "../../../codec/MessageCodec";
+import { Message } from "../../../codec/MessageCodec";
 
 export const enum ResultCode {
     Success = 0x00,
@@ -20,12 +20,12 @@ export class CommandServer<RequestT, ResponseT> {
         readonly name: string,
         protected readonly requestSchema: TlvSchema<RequestT>,
         protected readonly responseSchema: TlvSchema<ResponseT>,
-        protected readonly handler: (request: RequestT, session: Session<MatterDevice>, packetHeader: PacketHeader) => Promise<ResponseT> | ResponseT,
+        protected readonly handler: (request: RequestT, session: Session<MatterDevice>, message: Message) => Promise<ResponseT> | ResponseT,
     ) {}
 
-    async invoke(session: Session<MatterDevice>, args: TlvStream, packetHeader: PacketHeader): Promise<{ code: ResultCode, responseId: number, response: TlvStream }> {
+    async invoke(session: Session<MatterDevice>, args: TlvStream, message: Message): Promise<{ code: ResultCode, responseId: number, response: TlvStream }> {
         const request = this.requestSchema.decodeTlv(args);
-        const response = await this.handler(request, session, packetHeader);
+        const response = await this.handler(request, session, message);
         return { code: ResultCode.Success, responseId: this.responseId, response: this.responseSchema.encodeTlv(response) };
     }
 }

--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -105,7 +105,7 @@ export class MessageExchange<ContextT> {
         }
         if (messageId === this.sentMessageToAck?.payloadHeader.ackedMessageId) {
             // Received a message retransmission, this means that the other side didn't get our ack
-            // Resending the previously reply message which contains the ack
+            // Resending the previous reply message which contains the ack
             await this.channel.send(this.sentMessageToAck);
             return;
         }

--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -10,7 +10,7 @@ import { MatterController } from "../MatterController";
 import { MatterDevice } from "../MatterDevice";
 import { TlvInvokeRequest, TlvInvokeResponse, TlvReadRequest, TlvDataReport, TlvSubscribeRequest, TlvSubscribeResponse, StatusCode, TlvStatusResponse, TlvTimedRequest, TlvAttributeReport } from "./InteractionMessages";
 import { ByteArray, TlvSchema, TypeFromSchema } from "@project-chip/matter.js";
-import { PacketHeader } from "../../codec/MessageCodec";
+import { Message } from "../../codec/MessageCodec";
 
 export const enum MessageType {
     StatusResponse = 0x01,
@@ -81,7 +81,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
     async handleRequest(
         handleReadRequest: (request: ReadRequest) => DataReport,
         handleSubscribeRequest: (request: SubscribeRequest) => SubscribeResponse | undefined,
-        handleInvokeRequest: (request: InvokeRequest, paketHeader: PacketHeader) => Promise<InvokeResponse>,
+        handleInvokeRequest: (request: InvokeRequest, message: Message) => Promise<InvokeResponse>,
         handleTimedRequest: (request: TimedRequest) => Promise<void>,
     ) {
         let continueExchange = true;
@@ -105,7 +105,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                         break;
                     case MessageType.InvokeCommandRequest:
                         const invokeRequest = TlvInvokeRequest.decode(message.payload);
-                        const invokeResponse = await handleInvokeRequest(invokeRequest, message.packetHeader);
+                        const invokeResponse = await handleInvokeRequest(invokeRequest, message);
                         await this.exchange.send(MessageType.InvokeCommandResponse, TlvInvokeResponse.encode(invokeResponse));
                         break;
                     case MessageType.TimedRequest:


### PR DESCRIPTION
For Group clusters (and also others) we need to be able to access information from the package header when processing commands. In fact mainly the "request type" (multicast/unicast) and "is it a group request" is relevant based on the current knowledge but it should also not hurt to make all data available.

