### PR TITLE
Add nonVolatile and omitChanges Attribute options

### DIFF
--- a/src/matter/cluster/BasicInformationCluster.ts
+++ b/src/matter/cluster/BasicInformationCluster.ts
@@ -52,10 +52,10 @@ export const BasicInformationCluster = Cluster({
         productId: Attribute(4, TlvUInt16),
 
         /** User defined name for the Node. It is set during initial commissioning and may be updated by further reconfigurations. */
-        nodeLabel: WritableAttribute(5, TlvString32max, { nonVolatile: true, default: "", writeAcl: AccessLevel.Manage } ),
+        nodeLabel: WritableAttribute(5, TlvString32max, { persistent: true, default: "", writeAcl: AccessLevel.Manage } ),
 
         /** ISO 3166-1 alpha-2 code where the Node is located. Might affect some regulatory aspects. */
-        location: WritableAttribute(6, TlvString.bound({ length: 2 }), { nonVolatile: true, default: "XX", writeAcl: AccessLevel.Administer } ),
+        location: WritableAttribute(6, TlvString.bound({ length: 2 }), { persistent: true, default: "XX", writeAcl: AccessLevel.Administer } ),
 
         /** Version number of the hardware of the Node. The meaning of its value, and the versioning scheme, are vendor defined. */
         hardwareVersion: Attribute(7, TlvUInt16, { default: 0 }),
@@ -85,7 +85,7 @@ export const BasicInformationCluster = Cluster({
         serialNumber: OptionalAttribute(15, TlvString32max),
 
         /** Allows to disable the ability to configure the Node through an on-Node user interface. */
-        localConfigDisabled: OptionalWritableAttribute(16, TlvBoolean, { nonVolatile: true, default: false, writeAcl: AccessLevel.Manage } ),
+        localConfigDisabled: OptionalWritableAttribute(16, TlvBoolean, { persistent: true, default: false, writeAcl: AccessLevel.Manage } ),
 
         /** Indicates whether the Node can be reached over the non-native network for bridged devices. */
         reachable: OptionalAttribute(17, TlvBoolean, { default: true }),

--- a/src/matter/cluster/BasicInformationCluster.ts
+++ b/src/matter/cluster/BasicInformationCluster.ts
@@ -52,10 +52,10 @@ export const BasicInformationCluster = Cluster({
         productId: Attribute(4, TlvUInt16),
 
         /** User defined name for the Node. It is set during initial commissioning and may be updated by further reconfigurations. */
-        nodeLabel: WritableAttribute(5, TlvString32max, { default: "", writeAcl: AccessLevel.Manage } ),
+        nodeLabel: WritableAttribute(5, TlvString32max, { nonVolatile: true, default: "", writeAcl: AccessLevel.Manage } ),
 
         /** ISO 3166-1 alpha-2 code where the Node is located. Might affect some regulatory aspects. */
-        location: WritableAttribute(6, TlvString.bound({ length: 2 }), { default: "XX", writeAcl: AccessLevel.Administer } ),
+        location: WritableAttribute(6, TlvString.bound({ length: 2 }), { nonVolatile: true, default: "XX", writeAcl: AccessLevel.Administer } ),
 
         /** Version number of the hardware of the Node. The meaning of its value, and the versioning scheme, are vendor defined. */
         hardwareVersion: Attribute(7, TlvUInt16, { default: 0 }),
@@ -85,7 +85,7 @@ export const BasicInformationCluster = Cluster({
         serialNumber: OptionalAttribute(15, TlvString32max),
 
         /** Allows to disable the ability to configure the Node through an on-Node user interface. */
-        localConfigDisabled: OptionalWritableAttribute(16, TlvBoolean, { default: false, writeAcl: AccessLevel.Manage } ),
+        localConfigDisabled: OptionalWritableAttribute(16, TlvBoolean, { nonVolatile: true, default: false, writeAcl: AccessLevel.Manage } ),
 
         /** Indicates whether the Node can be reached over the non-native network for bridged devices. */
         reachable: OptionalAttribute(17, TlvBoolean, { default: true }),

--- a/src/matter/cluster/BindingCluster.ts
+++ b/src/matter/cluster/BindingCluster.ts
@@ -49,6 +49,6 @@ export const BindingCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 9.6.5 */
     attributes: {
         /** List of device types and corresponding revisions declaring endpoint conformance. */
-        binding: WritableAttribute(0, TlvArray(TlvTarget), { nonVolatile: true, default: [] }),
+        binding: WritableAttribute(0, TlvArray(TlvTarget), { persistent: true, default: [] }),
     },
 });

--- a/src/matter/cluster/BindingCluster.ts
+++ b/src/matter/cluster/BindingCluster.ts
@@ -49,6 +49,6 @@ export const BindingCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 9.6.5 */
     attributes: {
         /** List of device types and corresponding revisions declaring endpoint conformance. */
-        binding: WritableAttribute(0, TlvArray(TlvTarget), { default: [] }), /* non-volatile */
+        binding: WritableAttribute(0, TlvArray(TlvTarget), { nonVolatile: true, default: [] }),
     },
 });

--- a/src/matter/cluster/BridgedDeviceBasicInformationCluster.ts
+++ b/src/matter/cluster/BridgedDeviceBasicInformationCluster.ts
@@ -37,7 +37,7 @@ export const BasicInformationCluster = Cluster({
         productName: OptionalAttribute(3, TlvString32max),
 
         /** User defined name for the Node. It is set during initial commissioning and may be updated by further reconfigurations. */
-        nodeLabel: OptionalWritableAttribute(5, TlvString32max, { default: "", writeAcl: AccessLevel.Manage } ),
+        nodeLabel: OptionalWritableAttribute(5, TlvString32max, { nonVolatile: true, default: "", writeAcl: AccessLevel.Manage } ),
 
         /** Version number of the hardware of the Node. The meaning of its value, and the versioning scheme, are vendor defined. */
         hardwareVersion: OptionalAttribute(7, TlvUInt16, { default: 0 }),

--- a/src/matter/cluster/BridgedDeviceBasicInformationCluster.ts
+++ b/src/matter/cluster/BridgedDeviceBasicInformationCluster.ts
@@ -37,7 +37,7 @@ export const BasicInformationCluster = Cluster({
         productName: OptionalAttribute(3, TlvString32max),
 
         /** User defined name for the Node. It is set during initial commissioning and may be updated by further reconfigurations. */
-        nodeLabel: OptionalWritableAttribute(5, TlvString32max, { nonVolatile: true, default: "", writeAcl: AccessLevel.Manage } ),
+        nodeLabel: OptionalWritableAttribute(5, TlvString32max, { persistent: true, default: "", writeAcl: AccessLevel.Manage } ),
 
         /** Version number of the hardware of the Node. The meaning of its value, and the versioning scheme, are vendor defined. */
         hardwareVersion: OptionalAttribute(7, TlvUInt16, { default: 0 }),

--- a/src/matter/cluster/Cluster.ts
+++ b/src/matter/cluster/Cluster.ts
@@ -28,16 +28,16 @@ export const enum AccessLevel {
 }
 
 /* Interfaces and helper methods to define a cluster attribute */
-export interface Attribute<T> { id: number, schema: TlvSchema<T>, optional: boolean, readAcl: AccessLevel, writable: boolean, writeAcl?: AccessLevel, default?: T }
+export interface Attribute<T> { id: number, schema: TlvSchema<T>, optional: boolean, readAcl: AccessLevel, writable: boolean, nonVolatile?: boolean, omitChanges?: boolean, writeAcl?: AccessLevel, default?: T }
 export interface OptionalAttribute<T> extends Attribute<T> { optional: true }
 export interface WritableAttribute<T> extends Attribute<T> { writable: true }
 export interface OptionalWritableAttribute<T> extends OptionalAttribute<T> { writable: true }
 export type AttributeJsType<T extends Attribute<any>> = T extends Attribute<infer JsType> ? JsType : never;
-interface AttributeOptions<T> { default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel };
-export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): Attribute<T> => ({ id, schema, optional: false, writable: false, default: conformanceValue, readAcl });
-export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalAttribute<T> => ({ id, schema, optional: true, writable: false, default: conformanceValue, readAcl });
-export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: false, writable: true, default: conformanceValue, readAcl, writeAcl });
-export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: true, writable: true, default: conformanceValue, readAcl, writeAcl });
+interface AttributeOptions<T> { nonVolatile?: boolean, omitChanges?: boolean, default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel };
+export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): Attribute<T> => ({ id, schema, optional: false, writable: false, nonVolatile, omitChanges, default: conformanceValue, readAcl });
+export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalAttribute<T> => ({ id, schema, optional: true, writable: false, nonVolatile, omitChanges, default: conformanceValue, readAcl });
+export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: false, writable: true, nonVolatile, omitChanges, default: conformanceValue, readAcl, writeAcl });
+export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalWritableAttribute<T> => ({ id, schema, optional: true, writable: true, nonVolatile, omitChanges, default: conformanceValue, readAcl, writeAcl });
 
 /* Interfaces and helper methods to define a cluster command */
 export const TlvNoArguments = TlvObject({});

--- a/src/matter/cluster/Cluster.ts
+++ b/src/matter/cluster/Cluster.ts
@@ -28,16 +28,16 @@ export const enum AccessLevel {
 }
 
 /* Interfaces and helper methods to define a cluster attribute */
-export interface Attribute<T> { id: number, schema: TlvSchema<T>, optional: boolean, readAcl: AccessLevel, writable: boolean, nonVolatile?: boolean, omitChanges?: boolean, writeAcl?: AccessLevel, default?: T }
+export interface Attribute<T> { id: number, schema: TlvSchema<T>, optional: boolean, readAcl: AccessLevel, writable: boolean, persistent: boolean, omitChanges: boolean, writeAcl?: AccessLevel, default?: T }
 export interface OptionalAttribute<T> extends Attribute<T> { optional: true }
 export interface WritableAttribute<T> extends Attribute<T> { writable: true }
 export interface OptionalWritableAttribute<T> extends OptionalAttribute<T> { writable: true }
 export type AttributeJsType<T extends Attribute<any>> = T extends Attribute<infer JsType> ? JsType : never;
-interface AttributeOptions<T> { nonVolatile?: boolean, omitChanges?: boolean, default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel };
-export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): Attribute<T> => ({ id, schema, optional: false, writable: false, nonVolatile, omitChanges, default: conformanceValue, readAcl });
-export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalAttribute<T> => ({ id, schema, optional: true, writable: false, nonVolatile, omitChanges, default: conformanceValue, readAcl });
-export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: false, writable: true, nonVolatile, omitChanges, default: conformanceValue, readAcl, writeAcl });
-export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { nonVolatile = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalWritableAttribute<T> => ({ id, schema, optional: true, writable: true, nonVolatile, omitChanges, default: conformanceValue, readAcl, writeAcl });
+interface AttributeOptions<T> { persistent?: boolean, omitChanges?: boolean, default?: T, readAcl?: AccessLevel, writeAcl?: AccessLevel };
+export const Attribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): Attribute<T> => ({ id, schema, optional: false, writable: false, persistent, omitChanges, default: conformanceValue, readAcl });
+export const OptionalAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalAttribute<T> => ({ id, schema, optional: true, writable: false, persistent, omitChanges, default: conformanceValue, readAcl });
+export const WritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): WritableAttribute<T> => ({ id, schema, optional: false, writable: true, persistent, omitChanges, default: conformanceValue, readAcl, writeAcl });
+export const OptionalWritableAttribute = <T, V extends T>(id: number, schema: TlvSchema<T>, { persistent = false, omitChanges = false, default: conformanceValue, readAcl = AccessLevel.View, writeAcl = AccessLevel.View }: AttributeOptions<V> = {}): OptionalWritableAttribute<T> => ({ id, schema, optional: true, writable: true, persistent, omitChanges, default: conformanceValue, readAcl, writeAcl });
 
 /* Interfaces and helper methods to define a cluster command */
 export const TlvNoArguments = TlvObject({});

--- a/src/matter/cluster/LabelCluster.ts
+++ b/src/matter/cluster/LabelCluster.ts
@@ -34,7 +34,7 @@ export const UserLabelCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 9.9.4 */
     attributes: {
         /** An implementation SHALL support at least 4 list entries per node for all User Label cluster instances on the node. */
-        labelList: WritableAttribute(0, TlvArray(TlvLabel), { nonVolatile: true, default: [], writeAcl: AccessLevel.Manage }),
+        labelList: WritableAttribute(0, TlvArray(TlvLabel), { persistent: true, default: [], writeAcl: AccessLevel.Manage }),
     },
 });
 
@@ -52,6 +52,6 @@ export const FixedLabelCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 9.8.4 */
     attributes: {
         /** List of fixed labels. */
-        labelList: Attribute(0, TlvArray(TlvLabel), { nonVolatile: true, default: [] }),
+        labelList: Attribute(0, TlvArray(TlvLabel), { persistent: true, default: [] }),
     },
 });

--- a/src/matter/cluster/LabelCluster.ts
+++ b/src/matter/cluster/LabelCluster.ts
@@ -34,7 +34,7 @@ export const UserLabelCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 9.9.4 */
     attributes: {
         /** An implementation SHALL support at least 4 list entries per node for all User Label cluster instances on the node. */
-        labelList: WritableAttribute(0, TlvArray(TlvLabel), { default: [], writeAcl: AccessLevel.Manage }), /* non-volatile */
+        labelList: WritableAttribute(0, TlvArray(TlvLabel), { nonVolatile: true, default: [], writeAcl: AccessLevel.Manage }),
     },
 });
 
@@ -52,6 +52,6 @@ export const FixedLabelCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 9.8.4 */
     attributes: {
         /** List of fixed labels. */
-        labelList: Attribute(0, TlvArray(TlvLabel), { default: [] }), /* non-volatile */
+        labelList: Attribute(0, TlvArray(TlvLabel), { nonVolatile: true, default: [] }),
     },
 });

--- a/src/matter/cluster/NetworkCommissioningCluster.ts
+++ b/src/matter/cluster/NetworkCommissioningCluster.ts
@@ -266,7 +266,7 @@ export const NetworkCommissioningCluster = Cluster({
         interfaceEnabled: WritableAttribute(4, TlvBoolean, { default: true }), /* write = admin */
 
         /** Status of the last attempt either scan or connect to an operational network. */
-        lastNetworkingStatus: Attribute(5, TlvNullable(TlvEnum<NetworkCommissioningStatus>()), { default: null }), /* read = admin */
+        lastNetworkingStatus: Attribute(5, TlvNullable(TlvEnum<NetworkCommissioningStatus>()), { nonVolatile: true, default: null }), /* read = admin */
 
         /** NetworkID used in the last attempt to connect to an operational network. */
         lastNetworkId: Attribute(6, TlvNullable(TlvByteString.bound({ minLength: 1, maxLength: 32 })), { default: null }), /* read = admin */

--- a/src/matter/cluster/NetworkCommissioningCluster.ts
+++ b/src/matter/cluster/NetworkCommissioningCluster.ts
@@ -266,7 +266,7 @@ export const NetworkCommissioningCluster = Cluster({
         interfaceEnabled: WritableAttribute(4, TlvBoolean, { default: true }), /* write = admin */
 
         /** Status of the last attempt either scan or connect to an operational network. */
-        lastNetworkingStatus: Attribute(5, TlvNullable(TlvEnum<NetworkCommissioningStatus>()), { nonVolatile: true, default: null }), /* read = admin */
+        lastNetworkingStatus: Attribute(5, TlvNullable(TlvEnum<NetworkCommissioningStatus>()), { persistent: true, default: null }), /* read = admin */
 
         /** NetworkID used in the last attempt to connect to an operational network. */
         lastNetworkId: Attribute(6, TlvNullable(TlvByteString.bound({ minLength: 1, maxLength: 32 })), { default: null }), /* read = admin */

--- a/src/matter/cluster/OnOffCluster.ts
+++ b/src/matter/cluster/OnOffCluster.ts
@@ -93,7 +93,7 @@ export const OnOffCluster = Cluster({
     /** @see {@link MatterApplicationClusterSpecificationV1_0} § 1.5.6 */
     attributes: {
         /** Indicates whether the device type implemented on the endpoint is turned off (false) or turned on (true). */
-        onOff: Attribute(0,  TlvBoolean, { default: false }), /* reportable: true, scene:true - Specs 1.0 wrong here, using chip XMLs*/
+        onOff: Attribute(0,  TlvBoolean, { nonVolatile: true, default: false }), /* reportable: true, scene:true - Specs 1.0 wrong here, using chip XMLs*/
 
         // The following attributes are only needed for "Level Control for Lighting" support
 
@@ -113,7 +113,7 @@ export const OnOffCluster = Cluster({
         //offWaitTime: OptionalWritableAttribute(0x4002, TlvNullable(TlvUInt16), { default: 0 }), /* unit: 1/10s */
 
         /** Defines the desired startup behavior of a device when it is supplied with power. */
-        //startUpOnOff: OptionalWritableAttribute(0x4003, TlvNullable(TlvEnum<StartUpOnOff>()), { writeAcl: AccessLevel.Manage }),
+        //startUpOnOff: OptionalWritableAttribute(0x4003, TlvNullable(TlvEnum<StartUpOnOff>()), { nonVolatile: true, writeAcl: AccessLevel.Manage }),
     },
 
     /** @see {@link MatterApplicationClusterSpecificationV1_0} § 1.5.7 */

--- a/src/matter/cluster/OnOffCluster.ts
+++ b/src/matter/cluster/OnOffCluster.ts
@@ -93,7 +93,7 @@ export const OnOffCluster = Cluster({
     /** @see {@link MatterApplicationClusterSpecificationV1_0} § 1.5.6 */
     attributes: {
         /** Indicates whether the device type implemented on the endpoint is turned off (false) or turned on (true). */
-        onOff: Attribute(0,  TlvBoolean, { nonVolatile: true, default: false }), /* reportable: true, scene:true - Specs 1.0 wrong here, using chip XMLs*/
+        onOff: Attribute(0,  TlvBoolean, { persistent: true, default: false }), /* reportable: true, scene:true - Specs 1.0 wrong here, using chip XMLs*/
 
         // The following attributes are only needed for "Level Control for Lighting" support
 
@@ -113,7 +113,7 @@ export const OnOffCluster = Cluster({
         //offWaitTime: OptionalWritableAttribute(0x4002, TlvNullable(TlvUInt16), { default: 0 }), /* unit: 1/10s */
 
         /** Defines the desired startup behavior of a device when it is supplied with power. */
-        //startUpOnOff: OptionalWritableAttribute(0x4003, TlvNullable(TlvEnum<StartUpOnOff>()), { nonVolatile: true, writeAcl: AccessLevel.Manage }),
+        //startUpOnOff: OptionalWritableAttribute(0x4003, TlvNullable(TlvEnum<StartUpOnOff>()), { persistent: true, writeAcl: AccessLevel.Manage }),
     },
 
     /** @see {@link MatterApplicationClusterSpecificationV1_0} § 1.5.7 */

--- a/src/matter/cluster/OperationalCredentialsCluster.ts
+++ b/src/matter/cluster/OperationalCredentialsCluster.ts
@@ -8,7 +8,7 @@ import { TlvVendorId } from "../common/VendorId";
 import { TlvNodeId } from "../common/NodeId";
 import { TlvSubjectId } from "../common/SubjectId";
 import { TlvFabricId } from "../common/FabricId";
-import { TlvFabricIndex } from "../common/FabricIndex";
+import { FabricIndex, TlvFabricIndex } from "../common/FabricIndex";
 import { AccessLevel, Attribute, Cluster, Command, TlvNoResponse } from "./Cluster";
 import { MatterCoreSpecificationV1_0, TlvArray, TlvBoolean, TlvByteString, TlvEnum, TlvField, TlvNullable, TlvObject, TlvOptionalField, TlvString, TlvString32max, TlvUInt32, TlvUInt8 } from "@project-chip/matter.js";
 
@@ -242,22 +242,22 @@ export const OperationalCredentialsCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 11.17.6 */
     attributes: {
         /** Contains all NOCs applicable to this Node. */
-        nocs: Attribute(0, TlvArray(TlvNoc), { readAcl: AccessLevel.Administer }),
+        nocs: Attribute(0, TlvArray(TlvNoc), { nonVolatile: true, omitChanges: true, readAcl: AccessLevel.Administer }),
 
         /** Describes all fabrics to which this Node is commissioned. */
-        fabrics: Attribute(1, TlvArray(TlvFabricDescriptor)),
+        fabrics: Attribute(1, TlvArray(TlvFabricDescriptor), { nonVolatile: true }),
 
         /** Contains the number of Fabrics that are supported by the device. */
         supportedFabrics: Attribute(2, TlvUInt8.bound({ min: 5, max: 254 })),
 
         /** Contains the number of Fabrics to which the device is currently commissioned. */
-        commissionedFabrics: Attribute(3, TlvUInt8),
+        commissionedFabrics: Attribute(3, TlvUInt8, { nonVolatile: true }),
 
         /** Contains a read-only list of Trusted Root CA Certificates installed on the Node. */
-        trustedRootCertificates: Attribute(4, TlvArray(TlvByteString, { maxLength: 400 })),
+        trustedRootCertificates: Attribute(4, TlvArray(TlvByteString, { maxLength: 400 }), { nonVolatile: true, omitChanges: true }),
 
         /** Contain accessing fabric index. */
-        currentFabricIndex: Attribute(5, TlvFabricIndex),
+        currentFabricIndex: Attribute(5, TlvFabricIndex, { default: new FabricIndex(0)}),
     },
 
     /** @see {@link MatterCoreSpecificationV1_0} § 11.17.7 */

--- a/src/matter/cluster/OperationalCredentialsCluster.ts
+++ b/src/matter/cluster/OperationalCredentialsCluster.ts
@@ -242,19 +242,19 @@ export const OperationalCredentialsCluster = Cluster({
     /** @see {@link MatterCoreSpecificationV1_0} § 11.17.6 */
     attributes: {
         /** Contains all NOCs applicable to this Node. */
-        nocs: Attribute(0, TlvArray(TlvNoc), { nonVolatile: true, omitChanges: true, readAcl: AccessLevel.Administer }),
+        nocs: Attribute(0, TlvArray(TlvNoc), { persistent: true, omitChanges: true, readAcl: AccessLevel.Administer }),
 
         /** Describes all fabrics to which this Node is commissioned. */
-        fabrics: Attribute(1, TlvArray(TlvFabricDescriptor), { nonVolatile: true }),
+        fabrics: Attribute(1, TlvArray(TlvFabricDescriptor), { persistent: true }),
 
         /** Contains the number of Fabrics that are supported by the device. */
         supportedFabrics: Attribute(2, TlvUInt8.bound({ min: 5, max: 254 })),
 
         /** Contains the number of Fabrics to which the device is currently commissioned. */
-        commissionedFabrics: Attribute(3, TlvUInt8, { nonVolatile: true }),
+        commissionedFabrics: Attribute(3, TlvUInt8, { persistent: true }),
 
         /** Contains a read-only list of Trusted Root CA Certificates installed on the Node. */
-        trustedRootCertificates: Attribute(4, TlvArray(TlvByteString, { maxLength: 400 }), { nonVolatile: true, omitChanges: true }),
+        trustedRootCertificates: Attribute(4, TlvArray(TlvByteString, { maxLength: 400 }), { persistent: true, omitChanges: true }),
 
         /** Contain accessing fabric index. */
         currentFabricIndex: Attribute(5, TlvFabricIndex, { default: new FabricIndex(0)}),

--- a/src/matter/cluster/ScenesCluster.ts
+++ b/src/matter/cluster/ScenesCluster.ts
@@ -207,7 +207,7 @@ export const ScenesCluster = Cluster({
         nameSupport: Attribute(4, TlvNameSupportBitmap, { default: { sceneNames: true } }),
 
         /** Holds the Node ID (the IEEE address in case of Zigbee) of the node that last configured the Scene Table. */
-        lastConfiguredBy: OptionalAttribute(5, TlvNullable(TlvNodeId)),
+        lastConfiguredBy: OptionalAttribute(5, TlvNullable(TlvNodeId), { default: null }),
     },
 
     /** @see {@link MatterApplicationClusterSpecificationV1_0} § 1.4.9 */

--- a/src/matter/cluster/client/ClusterClient.ts
+++ b/src/matter/cluster/client/ClusterClient.ts
@@ -9,12 +9,12 @@ import { Attribute, Attributes, Command, Commands, AttributeJsType, WritableAttr
 type SignatureFromCommandSpec<C extends Command<any, any>> = (request: RequestType<C>) => Promise<ResponseType<C>>;
 type GetterTypeFromSpec<A extends Attribute<any>> = A extends OptionalAttribute<infer T> ? (T | undefined) : AttributeJsType<A>;
 type AttributeGetters<A extends Attributes> = { [P in keyof A as `get${Capitalize<string & P>}`]: () => Promise<GetterTypeFromSpec<A[P]>> };
-type WrittableAttributeNames<A extends Attributes> = {[K in keyof A]: A[K] extends WritableAttribute<any> ? K : never}[keyof A] | {[K in keyof A]: A[K] extends OptionalWritableAttribute<any> ? K : never}[keyof A];
-type AttributeSetters<A extends Attributes> = { [P in WrittableAttributeNames<A> as `set${Capitalize<string & P>}`]: (value: AttributeJsType<A[P]>) => Promise<void> };
+type WritableAttributeNames<A extends Attributes> = {[K in keyof A]: A[K] extends WritableAttribute<any> ? K : never}[keyof A] | {[K in keyof A]: A[K] extends OptionalWritableAttribute<any> ? K : never}[keyof A];
+type AttributeSetters<A extends Attributes> = { [P in WritableAttributeNames<A> as `set${Capitalize<string & P>}`]: (value: AttributeJsType<A[P]>) => Promise<void> };
 type AttributeSubscribers<A extends Attributes> = { [P in keyof A as `subscribe${Capitalize<string & P>}`]: (listener: (value: AttributeJsType<A[P]>, version: number) => void, minIntervalS: number, maxIntervalS: number) => Promise<void> };
 
 /** Strongly typed interface of a cluster client */
-export type ClusterClient<CommandsT extends Commands, AttributesT extends Attributes> = 
+export type ClusterClient<CommandsT extends Commands, AttributesT extends Attributes> =
     AttributeGetters<AttributesT>
     & AttributeSetters<AttributesT>
     & AttributeSubscribers<AttributesT>

--- a/src/matter/common/ChannelManager.ts
+++ b/src/matter/common/ChannelManager.ts
@@ -21,7 +21,7 @@ export class ChannelManager {
 
     getChannel(fabric: Fabric, nodeId: NodeId) {
         const result = this.channels.get(`${fabric.fabricId}/${nodeId}`);
-        if (result === undefined) throw new Error(`Can't find find a channel to node ${nodeId}`);
+        if (result === undefined) throw new Error(`Can't find a channel to node ${nodeId}`);
         return result;
     }
 

--- a/src/matter/session/secure/CaseServer.ts
+++ b/src/matter/session/secure/CaseServer.ts
@@ -23,7 +23,7 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
         try {
             await this.handleSigma1(exchange.session.getContext(), messenger);
         } catch (error) {
-            logger.error("An error occured during the commissioning", error);
+            logger.error("An error occurred during the commissioning", error);
             await messenger.sendError();
         }
     }


### PR DESCRIPTION
This PR adds two new Attribute options to be used in later PRs
* **nonVolatile** means that the value is persisted and initialized again on reboot/restart
* **ommitChanges** means that value changes should not send in subscriptions

I decided to add them as options and not types because I think the current types (optional, writable. normal and all combination) are already enough :-)

The PR also contains some minor typo fixes