### PR TITLE
Fix Subscriptions

### DIFF
--- a/src/matter/cluster/server/AttributeServer.ts
+++ b/src/matter/cluster/server/AttributeServer.ts
@@ -95,7 +95,7 @@ export class AttributeGetterServer<T> extends AttributeServer<T> {
 
     get(session?: SecureSession<MatterDevice>): T {
         // TODO: check ACL
-        
+        // TODO handle "version" for getter
         return this.getter(session);
     }
 }

--- a/src/matter/cluster/server/OperationalCredentialsServer.ts
+++ b/src/matter/cluster/server/OperationalCredentialsServer.ts
@@ -76,7 +76,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         return { status: OperationalCertStatus.Success, fabricIndex };
     },
 
-    getFabrics: (session?) => {
+    getFabrics: (session) => {
         if (session === undefined || !session.isSecure()) return []; // ???
         return session.getContext().getFabrics().map(fabric => ({
             fabricId: fabric.fabricId,
@@ -89,7 +89,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         }));
     },
 
-    getCurrentFabricIndex: (session?) => {
+    getCurrentFabricIndex: (session) => {
         if (session === undefined || !session.isSecure()) return FabricIndex.NO_FABRIC;
         return (session as SecureSession<MatterDevice>).getFabric()?.fabricIndex ?? FabricIndex.NO_FABRIC;
     },

--- a/src/matter/cluster/server/OperationalCredentialsServer.ts
+++ b/src/matter/cluster/server/OperationalCredentialsServer.ts
@@ -71,7 +71,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         return { status: OperationalCertStatus.Success, fabricIndex };
     },
 
-    getFabrics: session => {
+    getFabrics: (session?) => {
         if (session === undefined || !session.isSecure()) return []; // ???
         return session.getContext().getFabrics().map(fabric => ({
             fabricId: fabric.fabricId,
@@ -84,7 +84,7 @@ export const OperationalCredentialsClusterHandler: (conf: OperationalCredentials
         }));
     },
 
-    getCurrentFabricIndex: session => {
+    getCurrentFabricIndex: (session?) => {
         if (session === undefined || !session.isSecure()) return FabricIndex.NO_FABRIC;
         return (session as SecureSession<MatterDevice>).getFabric()?.fabricIndex ?? FabricIndex.NO_FABRIC;
     },

--- a/src/matter/common/ExchangeManager.ts
+++ b/src/matter/common/ExchangeManager.ts
@@ -95,8 +95,9 @@ export class ExchangeManager<ContextT> {
         if (exchange !== undefined) {
             await exchange.onMessageReceived(message);
         } else {
-            const exchange = await MessageExchange.fromInitialMessage(this.channelManager.getOrCreateChannel(channel, session), this.messageCounter, message, () => this.exchanges.delete(exchangeIndex));
+            const exchange = MessageExchange.fromInitialMessage(this.channelManager.getOrCreateChannel(channel, session), this.messageCounter, message, () => this.exchanges.delete(exchangeIndex));
             this.exchanges.set(exchangeIndex, exchange);
+            await exchange.onMessageReceived(message);
             const protocolHandler = this.protocols.get(message.payloadHeader.protocolId);
             if (protocolHandler === undefined) throw new Error(`Unsupported protocol ${message.payloadHeader.protocolId}`);
             await protocolHandler.onNewExchange(exchange, message);

--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -40,7 +40,7 @@ const MRP_STANDALONE_ACK_TIMEOUT = 200;
 const MAXIMUM_TRANSMISSION_TIME_MS = 9495; // 413 + 825 + 1485 + 2541 + 4231 ms as per specs
 
 export class MessageExchange<ContextT> {
-    static async fromInitialMessage<ContextT>(
+    static fromInitialMessage<ContextT>(
         channel: MessageChannel<ContextT>,
         messageCounter: MessageCounter,
         initialMessage: Message,
@@ -59,7 +59,6 @@ export class MessageExchange<ContextT> {
             initialMessage.payloadHeader.protocolId,
             closeCallback,
         )
-        await exchange.onMessageReceived(initialMessage);
         return exchange;
     }
 

--- a/src/matter/interaction/InteractionClient.ts
+++ b/src/matter/interaction/InteractionClient.ts
@@ -62,21 +62,17 @@ export class SubscriptionClient implements ProtocolHandler<MatterController> {
         let dataReport = await messenger.readDataReport();
         const subscriptionId = dataReport.subscriptionId;
         if (subscriptionId === undefined) {
-            return messenger.sendStatus(StatusCode.InvalidSubscription);
+            await messenger.sendStatus(StatusCode.InvalidSubscription);
+            throw new Error("Invalid Datareport without Subscription ID");
         }
         const listener = this.subscriptionListeners.get(subscriptionId);
         if (listener === undefined) {
-            return messenger.sendStatus(StatusCode.InvalidSubscription);
+            await messenger.sendStatus(StatusCode.InvalidSubscription);
+            throw new Error(`Unknown subscription ID ${subscriptionId}`);
         }
-        while (true) {
-            await messenger.sendStatus(StatusCode.Success);
-            listener(dataReport);
-            if (!dataReport.moreChunkedMessages) break;
-            dataReport = await messenger.readDataReport();
-            if (dataReport.subscriptionId !== subscriptionId) {
-                return messenger.sendStatus(StatusCode.InvalidSubscription);
-            }
-        }
+        await messenger.sendStatus(StatusCode.Success);
+
+        listener(dataReport);
     }
 }
 

--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -222,7 +222,7 @@ export const TlvSubscribeRequest = TlvObject({
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.5 */
 export const TlvSubscribeResponse = TlvObject({
     subscriptionId: TlvField(0, TlvUInt32),
-    maxIntervalCeilingSeconds: TlvField(2, TlvUInt16),
+    maxInterval: TlvField(2, TlvUInt16),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 

--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -180,6 +180,9 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                 }
                 const attributeReportBytes = TlvAttributeReport.encode(attributeReport).length;
                 if (messageSize + attributeReportBytes > MAX_SPDU_LENGTH) {
+                    if (messageSize === emptyDataReportBytes.length) {
+                        throw new Error(`Attribute report for is too long to fit in a single chunk, Array chunking not yet supported`);
+                    }
                     // Report doesn't fit, sending this chunk
                     await this.exchange.send(MessageType.ReportData, TlvDataReport.encode(dataReport));
                     await this.waitForSuccess();

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -219,7 +219,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             const subscriptionId = subscriptionHandler.subscriptionId;
 
             // Send initial data report to prime the subscription with initial data
-            await subscriptionHandler.sendInitialReport(messenger);
+            await subscriptionHandler.sendInitialReport(messenger, session);
 
             // Then send the subscription response
             return { subscriptionId, maxIntervalCeilingSeconds, interactionModelRevision: 1 };

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -265,8 +265,10 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             // Send initial data report to prime the subscription with initial data
             await subscriptionHandler.sendInitialReport(messenger, session);
 
+            const maxInterval = subscriptionHandler.getMaxInterval();
+            logger.info(`Created subscription ${subscriptionId} for Session ${session.getId()} with ${attributes.length} attributes. Updates: ${minIntervalFloorSeconds} - ${maxIntervalCeilingSeconds} => ${maxInterval} seconds`);
             // Then send the subscription response
-            return { subscriptionId, maxIntervalCeilingSeconds, interactionModelRevision: 1 };
+            return { subscriptionId, maxInterval, interactionModelRevision: 1 };
         }
     }
 

--- a/src/matter/interaction/SubscriptionHandler.ts
+++ b/src/matter/interaction/SubscriptionHandler.ts
@@ -31,8 +31,8 @@ export class SubscriptionHandler {
     private outstandingAttributeUpdates = new Map<string, PathValueVersion<any>>();
     private attributeListeners = new Map<string, (value: any, version: number) => void>();
     private isActive = false;
-    readonly maxInterval: number;
-    readonly sendInterval: number;
+    private readonly maxInterval: number;
+    private readonly sendInterval: number;
 
     constructor(
         readonly subscriptionId: number,

--- a/src/matter/interaction/SubscriptionHandler.ts
+++ b/src/matter/interaction/SubscriptionHandler.ts
@@ -7,7 +7,7 @@
 import { MatterDevice } from "../MatterDevice";
 import { InteractionServerMessenger } from "./InteractionMessenger";
 import { Fabric } from "../fabric/Fabric";
-import { AttributeWithPath, AttributePath, INTERACTION_PROTOCOL_ID } from "./InteractionServer";
+import { AttributeWithPath, AttributePath, INTERACTION_PROTOCOL_ID, attributePathToId } from "./InteractionServer";
 import { Time, Timer } from "../../time/Time";
 import { NodeId } from "../common/NodeId";
 import { TlvSchema } from "@project-chip/matter.js";
@@ -19,12 +19,11 @@ interface PathValueVersion<T> {
 }
 
 export class SubscriptionHandler {
-
-    static Builder = (server: MatterDevice, fabric: Fabric, peerNodeId: NodeId, attributes: AttributeWithPath[], minIntervalFloorSeconds: number, maxIntervalCeilingSeconds: number) => (subscriptionId: number) => new SubscriptionHandler(subscriptionId, server, fabric, peerNodeId, attributes, minIntervalFloorSeconds * 1000, maxIntervalCeilingSeconds * 1000);
-
     private lastUpdateTimeMs = 0;
-    private readonly listener = () => this.sendUpdate();
-    private updateTimer: Timer;
+    private updateTimer: Timer | null = null;
+    private outstandingAttributeUpdates = new Map<string, PathValueVersion<any>>();
+
+    private attributeListeners = new Map<string, (value: any, version: number) => void>();
 
     constructor(
         readonly subscriptionId: number,
@@ -35,37 +34,43 @@ export class SubscriptionHandler {
         private readonly minIntervalFloorMs: number,
         private readonly maxIntervalCeilingMs: number,
     ) {
-        attributes.forEach(({ attribute }) => attribute.addMatterListener(this.listener));
-        this.updateTimer = Time.getTimer(this.minIntervalFloorMs, () => this.sendUpdate()).start();
+        attributes.forEach(({ path, attribute }) => {
+            const listener = (value: any, version: number) => this.attributeChangeListener(path, attribute.schema, version, value);
+            this.attributeListeners.set(attributePathToId(path), listener);
+            attribute.addMatterListener(listener);
+        });
     }
 
     async sendUpdate() {
         const now = Date.now();
+        if (this.updateTimer) {
+            this.updateTimer.stop();
+            this.updateTimer = null;
+        }
         const timeSinceLastUpdateMs = now - this.lastUpdateTimeMs;
         if (timeSinceLastUpdateMs < this.minIntervalFloorMs) {
-            this.updateTimer.stop();
+            console.log(` Too soon, waiting ${this.minIntervalFloorMs - timeSinceLastUpdateMs}ms`);
             this.updateTimer = Time.getTimer(this.minIntervalFloorMs - timeSinceLastUpdateMs, () => this.sendUpdate()).start();
             return;
         }
 
-        const values = this.attributes.map(({ attribute, path }) => ({ path, valueVersion: attribute.getWithVersion(), schema: attribute.schema }));
-        await this.sendUpdateMessage(values);
+        const updatesToSend = Array.from(this.outstandingAttributeUpdates.values());
+        this.outstandingAttributeUpdates.clear();
         this.lastUpdateTimeMs = now;
+        await this.sendUpdateMessage(updatesToSend);
 
-        this.updateTimer.stop();
         this.updateTimer = Time.getTimer(this.maxIntervalCeilingMs, () => this.sendUpdate()).start();
     }
 
-    cancel() {
-        this.attributes.forEach(({ attribute }) => attribute.removeMatterListener(this.listener));
-        this.updateTimer.stop();
-    }
+    async sendInitialReport(messenger: InteractionServerMessenger) {
+        if (this.updateTimer) {
+            this.updateTimer.stop();
+            this.updateTimer = null;
+        }
 
-    private async sendUpdateMessage(values: PathValueVersion<any>[]) {
-        const exchange = this.server.initiateExchange(this.fabric, this.peerNodeId, INTERACTION_PROTOCOL_ID);
-        if (exchange === undefined) return;
-        const messenger = new InteractionServerMessenger(exchange);
+        const values = this.attributes.map(({ path, attribute }) => ({ path, schema: attribute.schema, valueVersion: attribute.getWithVersion() })).filter(({ valueVersion: { value } }) => value !== undefined) as PathValueVersion<any>[];
         await messenger.sendDataReport({
+            suppressResponse: false,
             subscriptionId: this.subscriptionId,
             interactionModelRevision: 1,
             values: values.map(({ path, schema, valueVersion: { value, version } }) => ({
@@ -76,7 +81,50 @@ export class SubscriptionHandler {
                 },
             })),
         });
+
         await messenger.waitForSuccess();
+
+        this.updateTimer = Time.getTimer(this.maxIntervalCeilingMs, () => this.sendUpdate()).start();
+    }
+
+    async attributeChangeListener(path: AttributePath, schema: TlvSchema<any>, version: number, value: any) {
+        console.log(`Attribute change listener for subscription ${this.subscriptionId}`, path, version, value);
+        this.outstandingAttributeUpdates.set(attributePathToId(path), { path, schema, valueVersion: { version, value } });
+        await this.sendUpdate();
+    }
+
+    cancel() {
+        this.attributes.forEach(({ path, attribute }) => {
+            const pathId = attributePathToId(path);
+            attribute.removeMatterListener(this.attributeListeners.get(pathId)!);
+            this.attributeListeners.delete(pathId);
+        });
+        if (this.updateTimer) {
+            this.updateTimer.stop();
+        }
+    }
+
+    private async sendUpdateMessage(values: PathValueVersion<any>[]) {
+        const exchange = this.server.initiateExchange(this.fabric, this.peerNodeId, INTERACTION_PROTOCOL_ID);
+        if (exchange === undefined) return;
+        const messenger = new InteractionServerMessenger(exchange);
+        await messenger.sendDataReport({
+            suppressResponse: !values.length, // suppressResponse ok for empty DataReports
+            subscriptionId: this.subscriptionId,
+            interactionModelRevision: 1,
+            values: values.map(({ path, schema, valueVersion: { value, version } }) => ({
+                value: {
+                    path,
+                    version,
+                    value: schema.encodeTlv(value),
+                },
+            })),
+        });
+
+        // Only expect answer for non-empty data reports
+        if (values.length) {
+            await messenger.waitForSuccess();
+        }
         messenger.close();
     }
 }

--- a/src/matter/interaction/SubscriptionHandler.ts
+++ b/src/matter/interaction/SubscriptionHandler.ts
@@ -124,7 +124,6 @@ export class SubscriptionHandler {
     }
 
     async attributeChangeListener(path: AttributePath, schema: TlvSchema<any>, version: number, value: any) {
-        console.log(`Attribute change listener for subscription ${this.subscriptionId}`, path, version, value);
         this.outstandingAttributeUpdates.set(attributePathToId(path), { path, schema, version, value });
         await this.sendUpdate();
     }
@@ -158,12 +157,9 @@ export class SubscriptionHandler {
             })),
         });
 
-        console.log('SENDING UPDATE MESSAGE', values.length);
         // Only expect answer for non-empty data reports
         if (values.length) {
-            console.log('WAITING FOR SUCCESS')
             await messenger.waitForSuccess();
-            console.log('GOT SUCCESS');
         }
         messenger.close();
     }

--- a/test/IntegrationTest.ts
+++ b/test/IntegrationTest.ts
@@ -218,7 +218,7 @@ describe("Integration", () => {
             onOffServer.attributes.onOff.set(false);
             const lastReport = await lastPromise;
 
-            assert.deepEqual(lastReport, { value: false, version: 2, time: startTime + 10 * 1000});
+            assert.deepEqual(lastReport, { value: false, version: 2, time: startTime + (60 * 60 + 4) * 1000});
         });
     });
 

--- a/test/IntegrationTest.ts
+++ b/test/IntegrationTest.ts
@@ -76,7 +76,7 @@ describe("Integration", () => {
     var client: MatterController;
 
     before(async () => {
-        Logger.defaultLogLevel = Level.INFO;
+        Logger.defaultLogLevel = Level.DEBUG;
         Time.get = () => fakeTime;
         Network.get = () => clientNetwork;
         client = await MatterController.create(
@@ -210,8 +210,8 @@ describe("Integration", () => {
             const { promise: lastPromise, resolver: lastResolver } = await getPromiseResolver<{value: boolean, version: number, time: number}>();
             callback = (value: boolean, version: number) => lastResolver({ value, version, time: Time.nowMs() });
 
-            // Verify that no update comes in after max cycle time 5s
-            await fakeTime.advanceTime(6 * 1000);
+            // Verify that no update comes in after max cycle time 1h
+            await fakeTime.advanceTime(60 * 60 * 1000);
 
             // ... but on next change immediately then
             await fakeTime.advanceTime(2 * 1000);

--- a/test/IntegrationTest.ts
+++ b/test/IntegrationTest.ts
@@ -181,42 +181,44 @@ describe("Integration", () => {
     });
 
     context("subscription", () => {
-        /*it("subscription sends regular updates", async () => {
-            const interactionClient = await client.connect(BigInt(1));
-            const onOffClient = ClusterClient(interactionClient, 1, OnOffCluster);
-            const startTime = Time.nowMs();
-            let lastReport: { value: boolean, version: number, time: number } | undefined;
-
-            await onOffClient.subscribeOn((value, version) => lastReport = { value, version, time: Time.nowMs() }, 0, 5);
-            await fakeTime.advanceTime(0);
-
-            assert.deepEqual(lastReport, { value: false, version: 0, time: startTime});
-
-            await fakeTime.advanceTime(8 * 1000);
-
-            assert.deepEqual(lastReport, { value: false, version: 0, time: startTime + 5 * 1000});
-
-            await fakeTime.advanceTime(5 * 1000);
-
-            assert.deepEqual(lastReport, { value: false, version: 0, time: startTime + 10 * 1000});
-        });*/
-
         it("subscription sends updates when the value changes", async () => {
             const interactionClient = await client.connect(new NodeId(BigInt(1)));
             const onOffClient = ClusterClient(interactionClient, 1, OnOffCluster);
             const startTime = Time.nowMs();
-            let callback = (value: boolean, version: number) => {};
-            await onOffClient.subscribeOnOff((value, version) => callback(value, version), 0, 5);
-            await fakeTime.advanceTime(0);
 
-            const { promise, resolver } = await getPromiseResolver<{value: boolean, version: number, time: number}>();
-            callback = (value: boolean, version: number) => resolver({ value, version, time: Time.nowMs() });
+            // Await initial Datareport
+            const { promise: firstPromise, resolver: firstResolver } = await getPromiseResolver<{value: boolean, version: number, time: number}>();
+            let callback = (value: boolean, version: number) => firstResolver({ value, version, time: Time.nowMs() });
+
+            await onOffClient.subscribeOnOff((value, version) => callback(value, version), 0, 5);
+
+            await fakeTime.advanceTime(0);
+            const firstReport = await firstPromise;
+            assert.deepEqual(firstReport, { value: false, version: 0, time: startTime});
+
+            // Await update Report on value change
+            const { promise: updatePromise, resolver: updateResolver } = await getPromiseResolver<{value: boolean, version: number, time: number}>();
+            callback = (value: boolean, version: number) => updateResolver({ value, version, time: Time.nowMs() });
 
             await fakeTime.advanceTime(2 * 1000);
             onOffServer.attributes.onOff.set(true);
-            const lastReport = await promise;
+            const updateReport = await updatePromise;
 
-            assert.deepEqual(lastReport, { value: true, version: 1, time: startTime + 2 * 1000});
+            assert.deepEqual(updateReport, { value: true, version: 1, time: startTime + 2 * 1000});
+
+            // Await update Report on value change without in between update
+            const { promise: lastPromise, resolver: lastResolver } = await getPromiseResolver<{value: boolean, version: number, time: number}>();
+            callback = (value: boolean, version: number) => lastResolver({ value, version, time: Time.nowMs() });
+
+            // Verify that no update comes in after max cycle time 5s
+            await fakeTime.advanceTime(6 * 1000);
+
+            // ... but on next change immediately then
+            await fakeTime.advanceTime(2 * 1000);
+            onOffServer.attributes.onOff.set(false);
+            const lastReport = await lastPromise;
+
+            assert.deepEqual(lastReport, { value: false, version: 2, time: startTime + 10 * 1000});
         });
     });
 

--- a/test/matter/interaction/InteractionProtocolTest.ts
+++ b/test/matter/interaction/InteractionProtocolTest.ts
@@ -29,6 +29,7 @@ const READ_REQUEST: ReadRequest = {
 
 const READ_RESPONSE: DataReport = {
     interactionModelRevision: 1,
+    suppressResponse: false,
     values: [
         { value: {
             path: {


### PR DESCRIPTION
This PR is a bigger overhaul to fix issues the former codebase had with subscriptions. basically the issues are about the following topics:
1. The subscription IDs needs to be "unique for the publisher". The former codebase had then always starting at 0 for each SecureSession where a subscription was started, so they were always overlapping as soon as a device did multiple subscriptions. This lead to issues with at least iOS. The PR changes to a "started at random" globally increase ID (like chiptool does it too)
2. The subscription initialization process was not followed. We missed the "priming the subscription with initial data" which needs to happen after the subscripion Request and before sending the subscription initialization response.

The PR also adds handling to only send out data updates and not slways the full data (as it was before).

Additionally the PR also adds support for incoming chunked data reports when used as controller because also needed for testing puroposes.

I could not really split that up further because the changes are somewhat connected, so I hope we can review as is.

I tested with iOS, Google and Alexa