### PR TITLE
Make DataReport fields optional because clients send so

### DIFF
--- a/src/matter/cluster/server/AttributeServer.ts
+++ b/src/matter/cluster/server/AttributeServer.ts
@@ -23,7 +23,9 @@ export class AttributeServer<T> {
         readonly isWritable: boolean,
         defaultValue: T,
     ) {
-        validator(defaultValue, name);
+        if (defaultValue !== undefined) {
+            validator(defaultValue, name);
+        }
         this.value = defaultValue;
     }
 
@@ -95,7 +97,7 @@ export class AttributeGetterServer<T> extends AttributeServer<T> {
 
     get(session?: SecureSession<MatterDevice>): T {
         // TODO: check ACL
-        
+
         return this.getter(session);
     }
 }

--- a/src/matter/cluster/server/AttributeServer.ts
+++ b/src/matter/cluster/server/AttributeServer.ts
@@ -23,9 +23,7 @@ export class AttributeServer<T> {
         readonly isWritable: boolean,
         defaultValue: T,
     ) {
-        if (defaultValue !== undefined) {
-            validator(defaultValue, name);
-        }
+        validator(defaultValue, name);
         this.value = defaultValue;
     }
 

--- a/src/matter/interaction/InteractionClient.ts
+++ b/src/matter/interaction/InteractionClient.ts
@@ -76,6 +76,7 @@ export class InteractionClient {
                 interactionModelRevision: 1,
                 isFabricFiltered: true,
             });
+            response.values = response.values ?? [];
 
             return response.values.map(({ value: { path: {endpointId, clusterId, attributeId}, version, value }}) => ({ endpointId, clusterId, attributeId, version, value }));
         });
@@ -88,6 +89,7 @@ export class InteractionClient {
                 interactionModelRevision: 1,
                 isFabricFiltered: true,
             });
+            response.values = response.values ?? [];
 
             const value = response.values.map(({value}) => value).find(({ path }) => endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId);
             if (value === undefined) {
@@ -121,6 +123,7 @@ export class InteractionClient {
             });
 
             this.subscriptionListeners.set(subscriptionId, (dataReport: DataReport) => {
+                if (!dataReport.values) return;
                 const value = dataReport.values.map(({value}) => value).find(({ path }) => endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId);
                 if (value === undefined) return;
                 listener(schema.decodeTlv(value.value), value.version);

--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -95,9 +95,9 @@ export const TlvAttributeReport = TlvObject({
 
 export const TlvDataReport = TlvObject({
     subscriptionId: TlvOptionalField(0, TlvUInt32),
-    values: TlvField(1, TlvArray(TlvAttributeReport)),
+    values: TlvOptionalField(1, TlvArray(TlvAttributeReport)), // Mandatory but chip tool do not send it
     moreChunkedMessages: TlvOptionalField(3, TlvBoolean),
-    suppressResponse: TlvOptionalField(4, TlvBoolean),
+    suppressResponse: TlvOptionalField(4, TlvBoolean), // Mandatory but chip tool do not send it
     interactionModelRevision: TlvField(0xFF, TlvUInt8),
 });
 

--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -82,7 +82,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
         handleSubscribeRequest: (request: SubscribeRequest) => SubscribeResponse | undefined,
         handleInvokeRequest: (request: InvokeRequest) => Promise<InvokeResponse>,
         handleTimedRequest: (request: TimedRequest) => Promise<void>,
-    ) { 
+    ) {
         let continueExchange = true;
         try {
             while (continueExchange) {
@@ -128,6 +128,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
     async sendDataReport(dataReport: DataReport) {
         const messageBytes = TlvDataReport.encode(dataReport);
         if (messageBytes.length > MAX_SPDU_LENGTH) {
+            dataReport.values = dataReport.values ?? [];
             // DataReport is too long, it needs to be sent in chunked
             const attributeReportsToSend = [...dataReport.values];
             dataReport.values.length = 0;


### PR DESCRIPTION
According to specs the values and supporessResponse fields are mandatory in a DataReport sent by a subscription.

The reality is that chip-tool apps sometimes send the reports without these fields, so we make them optional and add Code to handle this