### PR TITLE
Initialize all Attribute fields for Server

### DIFF
--- a/src/matter/cluster/server/AttributeServer.ts
+++ b/src/matter/cluster/server/AttributeServer.ts
@@ -23,7 +23,9 @@ export class AttributeServer<T> {
         readonly isWritable: boolean,
         defaultValue: T,
     ) {
-        validator(defaultValue, name);
+        if (defaultValue !== undefined) {
+            validator(defaultValue, name);
+        }
         this.value = defaultValue;
     }
 
@@ -95,7 +97,7 @@ export class AttributeGetterServer<T> extends AttributeServer<T> {
 
     get(session?: SecureSession<MatterDevice>): T {
         // TODO: check ACL
-        
+
         return this.getter(session);
     }
 }

--- a/src/matter/interaction/InteractionServer.ts
+++ b/src/matter/interaction/InteractionServer.ts
@@ -41,7 +41,7 @@ export class ClusterServer<ClusterT extends Cluster<any, any, any, any>> {
             clusterRevision: clusterDef.revision,
             featureMap: features,
         };
-        for (const name in attributesInitialValues) {
+        for (const name in attributeDefs) {
             let { id, schema, writable } = attributeDefs[name];
             const validator = typeof schema.validate === 'function' ? schema.validate.bind(schema) : undefined;
             const getter = (handlers as any)[`get${capitalize(name)}`];
@@ -165,7 +165,7 @@ export class InteractionServer implements ProtocolHandler<MatterDevice> {
             .map(({ path, attribute }) => {
                 const { value, version } = attribute.getWithVersion(exchange.session);
                 return { path, value, version, schema: attribute.schema };
-            });
+            }).filter(({ value }) => value !== undefined);
 
         return {
             interactionModelRevision: 1,

--- a/src/matter/interaction/SubscriptionHandler.ts
+++ b/src/matter/interaction/SubscriptionHandler.ts
@@ -48,7 +48,7 @@ export class SubscriptionHandler {
             return;
         }
 
-        const values = this.attributes.map(({ attribute, path }) => ({ path, valueVersion: attribute.getWithVersion(), schema: attribute.schema }));
+        const values = this.attributes.map(({ attribute, path }) => ({ path, valueVersion: attribute.getWithVersion(), schema: attribute.schema })).filter(({ valueVersion: { value } }) => value !== undefined);
         await this.sendUpdateMessage(values);
         this.lastUpdateTimeMs = now;
 


### PR DESCRIPTION
While playing around with subscriptions I noticed that we only initialize the attributes that are defined with default values for a cluster. Fields that are not in the "attributesInitialValues" are potentially never initialized correctly.

To fix this I now iterate over all attribute fields. But this means that we now could have undefined as value which basically is better then mitting attributeservers. For this I added filter in the relevant places to filter out undefined values when sending  read responses or DataReports on subscriptions. 