### PR TITLE
Fix ClusterServer typing

### DIFF
--- a/test/IntegrationTest.ts
+++ b/test/IntegrationTest.ts
@@ -72,7 +72,7 @@ const fakeTime = new TimeFake(TIME_START);
 
 describe("Integration", () => {
     var server: MatterDevice;
-    var onOffServer: ClusterServer<typeof OnOffCluster>;
+    var onOffServer: ClusterServer<any, any, any, any>;
     var client: MatterController;
 
     before(async () => {


### PR DESCRIPTION
This should prevent future bugs in the code.

The fix required to make explicit generic parameters typing one level deeper.