### PR TITLE
Implement retransmission backoff as per spec and reject with error

### DIFF
--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -250,12 +250,6 @@ export class MessageExchange<ContextT> {
         const resubmissionBackoffTime = this.getResubmissionBackOffTime(retransmissionCount);
         logger.debug(`Resubmit message ${message.packetHeader.messageId} (attempt ${retransmissionCount}, next backoff time ${resubmissionBackoffTime}ms))`);
 
-        if (retransmissionCount === 1) {
-            // this.session.getContext().announce(); // TODO: announce
-        }
-        const resubmissionBackoffTime = this.getResubmissionBackOffTime(retransmissionCount);
-        logger.debug(`Resubmit message ${message.packetHeader.messageId} (attempt ${retransmissionCount}, next backoff time ${resubmissionBackoffTime}ms))`);
-
         this.channel.send(message)
             .then(() => {
                 this.retransmissionTimer = Time.getTimer(resubmissionBackoffTime, () => this.retransmitMessage(message, retransmissionCount))

--- a/src/matter/session/SecureSession.ts
+++ b/src/matter/session/SecureSession.ts
@@ -8,7 +8,13 @@ import { Message, MessageCodec, Packet } from "../../codec/MessageCodec";
 import { Crypto } from "../../crypto/Crypto";
 import { Fabric } from "../fabric/Fabric";
 import { SubscriptionHandler } from "../interaction/SubscriptionHandler";
-import { DEFAULT_ACTIVE_RETRANSMISSION_TIMEOUT_MS, DEFAULT_IDLE_RETRANSMISSION_TIMEOUT_MS, DEFAULT_RETRANSMISSION_RETRIES, Session } from "./Session";
+import {
+    DEFAULT_ACTIVE_RETRANSMISSION_TIMEOUT_MS,
+    DEFAULT_IDLE_RETRANSMISSION_TIMEOUT_MS,
+    DEFAULT_RETRANSMISSION_RETRIES,
+    SLEEPY_ACTIVE_THRESHOLD_MS,
+    Session,
+} from "./Session";
 import { UNDEFINED_NODE_ID } from "./SessionManager";
 import { NodeId } from "../common/NodeId";
 import { ByteArray, DataWriter, Endian } from "@project-chip/matter.js";
@@ -19,6 +25,8 @@ const SESSION_RESUMPTION_KEYS_INFO = ByteArray.fromString("SessionResumptionKeys
 export class SecureSession<T> implements Session<T> {
     private nextSubscriptionId = 0;
     private readonly subscriptions = new Array<SubscriptionHandler>();
+    private timestamp = Date.now();
+    private activeTimestamp = Date.now();
 
     static async create<T>(context: T, id: number, fabric: Fabric | undefined, peerNodeId: NodeId, peerSessionId: number, sharedSecret: ByteArray, salt: ByteArray, isInitiator: boolean, isResumption: boolean, idleRetransTimeoutMs?: number, activeRetransTimeoutMs?: number) {
         const keys = await Crypto.hkdf(sharedSecret, salt, isResumption ? SESSION_RESUMPTION_KEYS_INFO : SESSION_KEYS_INFO, 16 * 3);
@@ -47,13 +55,24 @@ export class SecureSession<T> implements Session<T> {
         return true;
     }
 
+    touchSessionTimestamps(messageSent: boolean) {
+        this.timestamp = Date.now();
+        if (messageSent) {
+            this.activeTimestamp = this.timestamp;
+        }
+    }
+
+    isPeerActive(): boolean {
+        return (Date.now() - this.activeTimestamp) < SLEEPY_ACTIVE_THRESHOLD_MS;
+    }
+
     decode({ header, bytes }: Packet): Message {
         const headerBytes = MessageCodec.encodePacketHeader(header);
         const securityFlags = headerBytes[3];
         const nonce = this.generateNonce(securityFlags, header.messageId, this.peerNodeId);
         return MessageCodec.decodePayload({ header, bytes: Crypto.decrypt(this.decryptKey, bytes, nonce, headerBytes) });
     }
-    
+
     encode(message: Message): Packet {
         message.packetHeader.sessionId = this.peerSessionId;
         const {header, bytes} = MessageCodec.encodePayload(message);

--- a/src/matter/session/Session.ts
+++ b/src/matter/session/Session.ts
@@ -9,7 +9,16 @@ import { NodeId } from "../common/NodeId";
 
 export const DEFAULT_IDLE_RETRANSMISSION_TIMEOUT_MS = 5000;
 export const DEFAULT_ACTIVE_RETRANSMISSION_TIMEOUT_MS = 300;
-export const DEFAULT_RETRANSMISSION_RETRIES = 2;
+export const DEFAULT_RETRANSMISSION_RETRIES = 5;
+
+/** Maximum sleep interval of node when in active mode. */
+export const SLEEPY_ACTIVE_INTERVAL_MS = 300;
+
+/** Maximum sleep interval of node when in idle mode. */
+export const SLEEPY_IDLE_INTERVAL_MS = 300;
+
+/** Minimum amount the node SHOULD stay awake after network activity. */
+export const SLEEPY_ACTIVE_THRESHOLD_MS = 4000;
 
 interface MrpParameters {
     idleRetransmissionTimeoutMs: number,
@@ -28,4 +37,6 @@ export interface Session<T> {
     getPeerSessionId(): number;
     getNodeId(): NodeId | undefined;
     getPeerNodeId(): NodeId | undefined;
+    touchSessionTimestamps(messageSent: boolean): void;
+    isPeerActive(): boolean;
 }

--- a/src/matter/session/Session.ts
+++ b/src/matter/session/Session.ts
@@ -37,6 +37,6 @@ export interface Session<T> {
     getPeerSessionId(): number;
     getNodeId(): NodeId | undefined;
     getPeerNodeId(): NodeId | undefined;
-    touchSessionTimestamps(messageSent: boolean): void;
+    notifyActivity(messageReceived: boolean): void;
     isPeerActive(): boolean;
 }

--- a/src/matter/session/UnsecureSession.ts
+++ b/src/matter/session/UnsecureSession.ts
@@ -22,6 +22,14 @@ export class UnsecureSession<T> implements Session<T> {
         return false;
     }
 
+    touchSessionTimestamps(messageSent: boolean) {
+        // Do nothing
+    }
+
+    isPeerActive(): boolean {
+        return true;
+    }
+
     decode(packet: Packet): Message {
         return MessageCodec.decodePayload(packet);
     }

--- a/src/matter/session/UnsecureSession.ts
+++ b/src/matter/session/UnsecureSession.ts
@@ -22,7 +22,7 @@ export class UnsecureSession<T> implements Session<T> {
         return false;
     }
 
-    touchSessionTimestamps(messageSent: boolean) {
+    notifyActivity(messageReceived: boolean) {
         // Do nothing
     }
 


### PR DESCRIPTION
This PR is implementing a retransmission as per spec, especially regarding
* the increasing delay fir backoff time
* default number of tries (5 instead of 2)
* respecing different backoffs based on node active status of session

Additionally there was no promise rejection in the case of "all retransmissions were not answered" so there was a good chance to have just a haning code that never continues when waiting for a send result. So now also this case rejects (yes might need some error handling on other code later) and we also reject with an error object instead of nothing :-)