### PR TITLE
Do not forget message to ack if we send out "just" a Standalone ack

### DIFF
--- a/src/matter/common/ExchangeManager.ts
+++ b/src/matter/common/ExchangeManager.ts
@@ -82,7 +82,8 @@ export class ExchangeManager<ContextT> {
     }
 
     private async onMessage(channel: Channel<ByteArray>, messageBytes: ByteArray) {
-        var packet = MessageCodec.decodePacket(messageBytes);
+        const packet = MessageCodec.decodePacket(messageBytes);
+
         if (packet.header.sessionType === SessionType.Group) throw new Error("Group messages are not supported");
 
         const session = this.sessionManager.getSession(packet.header.sessionId);

--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -99,11 +99,7 @@ export class MessageExchange<ContextT> {
         if (messageId === this.receivedMessageToAck?.packetHeader.messageId) {
             // Received a message retransmission but the reply is not ready yet, ignoring
             if (requiresAck) {
-                try {
-                    await this.send(MessageType.StandaloneAck, new ByteArray(0));
-                } catch (error) {
-                    logger.error("Failed to send ack", error);
-                }
+                await this.send(MessageType.StandaloneAck, new ByteArray(0));
             }
             return;
         }

--- a/src/matter/common/MessageExchange.ts
+++ b/src/matter/common/MessageExchange.ts
@@ -99,7 +99,11 @@ export class MessageExchange<ContextT> {
         if (messageId === this.receivedMessageToAck?.packetHeader.messageId) {
             // Received a message retransmission but the reply is not ready yet, ignoring
             if (requiresAck) {
-                await this.send(MessageType.StandaloneAck, new ByteArray(0));
+                try {
+                    await this.send(MessageType.StandaloneAck, new ByteArray(0));
+                } catch (error) {
+                    logger.error("Failed to send ack", error);
+                }
             }
             return;
         }
@@ -161,7 +165,9 @@ export class MessageExchange<ContextT> {
             },
             payload,
         };
-        this.receivedMessageToAck = undefined;
+        if (messageType !== MessageType.StandaloneAck) {
+            this.receivedMessageToAck = undefined;
+        }
         let ackPromise: Promise<void> | undefined;
         if (message.payloadHeader.requiresAck) {
             this.sentMessageToAck = message;


### PR DESCRIPTION
When we send out a Standalone Ack because of a Duplicate (or close) we should not "forget" the message which is still in transit and waits to be acked officially, so not clear it.