### PR TITLE
Initial commit of Water Content Measurement Clusters.

### DIFF
--- a/src/matter/cluster/WaterContentMeasurementCluster.ts
+++ b/src/matter/cluster/WaterContentMeasurementCluster.ts
@@ -10,17 +10,19 @@ import {BitFlag, MatterApplicationClusterSpecificationV1_0, TlvBitmap, TlvInt16,
 
 /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.4 */
 const  attributes = {
-       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
-       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
+    /** Represents the water content in % as follows: MeasuredValue = 100 x water content */
+    measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
 
-       /** Indicates the minimum value of MeasuredValue that can be measured. */
-       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
+    /** Indicates the minimum value of MeasuredValue that can be measured. */
+    minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
 
-       /** Indicates the maximum value of MeasuredValue that can be measured. */
-       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
+    /** Indicates the maximum value of MeasuredValue that can be measured. */
+    maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
 
-       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
-   };
+    /** The magnitude of the possible error that is associated with MeasuredValue 
+    * attribute using the same unit */
+    tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
+};
 
 /**
  * Attributes and commands for Percentage of water in the air.

--- a/src/matter/cluster/WaterContentMeasurementCluster.ts
+++ b/src/matter/cluster/WaterContentMeasurementCluster.ts
@@ -4,74 +4,57 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
 import {Attribute, OptionalAttribute, Cluster, Command, TlvNoArguments, TlvNoResponse} from "./Cluster";
 import {BitFlag, MatterApplicationClusterSpecificationV1_0, TlvBitmap, TlvInt16, TlvUInt16, TlvEnum, TlvField, TlvNullable, TlvObject, TlvSchema, TlvUInt8} from "@project-chip/matter.js";
 
+/** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.4 */
+const  attributes = {
+       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
+       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
+
+       /** Indicates the minimum value of MeasuredValue that can be measured. */
+       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
+
+       /** Indicates the maximum value of MeasuredValue that can be measured. */
+       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
+
+       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
+   };
+
 /**
- * Attributes and commands for WaterContent Measurement.
+ * Attributes and commands for Percentage of water in the air.
  *
- * @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6
+ * @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3
  */
-/** Percentage of water in the air */
 export const RelativeHumidityCluster = Cluster({
     id: 0x0405,
     name: "RelativeHumidityMeasurement",
     revision: 3,
-
-    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3 */
-    attributes: {
-       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
-       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
-
-       /** Indicates the minimum value of MeasuredValue that can be measured. */
-       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
-
-       /** Indicates the maximum value of MeasuredValue that can be measured. */
-       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
-
-       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
-   },
+    attributes,
 });
 
-/** Percentage of water on the leaves of plants */
+/**
+ * Attributes and commands for Percentage of water in plants.
+ *
+ * @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3
+ */
 export const LeafWetnessMeasurementCluster = Cluster({
     id: 0x0407,
     name: "LeafWetnessMeasurement",
     revision: 3,
-
-    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3 */
-    attributes: {
-       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
-       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
-
-       /** Indicates the minimum value of MeasuredValue that can be measured. */
-       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
-
-       /** Indicates the maximum value of MeasuredValue that can be measured. */
-       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
-
-       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
-   },
+    attributes,
 });
 
-/** Percentage of water in the soil */
+/**
+ * Attributes and commands for Percentage of water in the soil.
+ *
+ * @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3
+ */
 export const SoilMoistureMeasurementCluster = Cluster({
     id: 0x0408, 
     name: "SoilMoistureMeasurement",
     revision: 3,
-
-    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3 */
-    attributes: {
-       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
-       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
-
-       /** Indicates the minimum value of MeasuredValue that can be measured. */
-       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
-
-       /** Indicates the maximum value of MeasuredValue that can be measured. */
-       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
-
-       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
-   },
+    attributes,
 });
 

--- a/src/matter/cluster/WaterContentMeasurementCluster.ts
+++ b/src/matter/cluster/WaterContentMeasurementCluster.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Attribute, OptionalAttribute, Cluster, Command, TlvNoArguments, TlvNoResponse} from "./Cluster";
+import {BitFlag, MatterApplicationClusterSpecificationV1_0, TlvBitmap, TlvInt16, TlvUInt16, TlvEnum, TlvField, TlvNullable, TlvObject, TlvSchema, TlvUInt8} from "@project-chip/matter.js";
+
+/**
+ * Attributes and commands for WaterContent Measurement.
+ *
+ * @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6
+ */
+/** Percentage of water in the air */
+export const RelativeHumidityCluster = Cluster({
+    id: 0x0405,
+    name: "RelativeHumidityMeasurement",
+    revision: 3,
+
+    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3 */
+    attributes: {
+       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
+       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
+
+       /** Indicates the minimum value of MeasuredValue that can be measured. */
+       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
+
+       /** Indicates the maximum value of MeasuredValue that can be measured. */
+       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
+
+       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
+   },
+});
+
+/** Percentage of water on the leaves of plants */
+export const LeafWetnessMeasurementCluster = Cluster({
+    id: 0x0407,
+    name: "LeafWetnessMeasurement",
+    revision: 3,
+
+    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3 */
+    attributes: {
+       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
+       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
+
+       /** Indicates the minimum value of MeasuredValue that can be measured. */
+       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
+
+       /** Indicates the maximum value of MeasuredValue that can be measured. */
+       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
+
+       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
+   },
+});
+
+/** Percentage of water in the soil */
+export const SoilMoistureMeasurementCluster = Cluster({
+    id: 0x0408, 
+    name: "SoilMoistureMeasurement",
+    revision: 3,
+
+    /** @see {@link MatterApplicationClusterSpecificationV1_0} § 2.6.3 */
+    attributes: {
+       /** MeasuredValue represents the water content in % as follows: MeasuredValue = 100 x water content */
+       measuredValue: Attribute(0, TlvNullable(TlvUInt16.bound({min: 0, max: 10000}))),
+
+       /** Indicates the minimum value of MeasuredValue that can be measured. */
+       minMeasuredValue: Attribute(1, TlvNullable(TlvUInt16.bound({min: 0}))),
+
+       /** Indicates the maximum value of MeasuredValue that can be measured. */
+       maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
+
+       tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
+   },
+});
+

--- a/src/matter/cluster/WaterContentMeasurementCluster.ts
+++ b/src/matter/cluster/WaterContentMeasurementCluster.ts
@@ -19,8 +19,10 @@ const  attributes = {
     /** Indicates the maximum value of MeasuredValue that can be measured. */
     maxMeasuredValue: Attribute(2, TlvNullable(TlvUInt16.bound({max: 10000}))),
 
-    /** The magnitude of the possible error that is associated with MeasuredValue 
-    * attribute using the same unit */
+    /** 
+     * The magnitude of the possible error that is associated with MeasuredValue 
+     * attribute using the same unit 
+     */
     tolerance: OptionalAttribute(3, TlvUInt16.bound({min: 0, max: 2048})),
 };
 


### PR DESCRIPTION
 Contains three clusters: RelativeHumidityCluster,  LeafWetnessMeasurementCluster and SoilMoistureMeasurementCluster. 

Tested with live weather data in Google Home

This is the last of the "measurement and sensing" clusters from the spec.