### PR TITLE
Really check for Statuscode errors and return Error classes

### DIFF
--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -87,14 +87,14 @@ class InteractionMessenger<ContextT> {
         return message;
     }
 
+    close() {
+        this.exchangeBase.close();
+    }
+
     protected throwIfError(messageType: number, payload: ByteArray) {
         if (messageType !== MessageType.StatusResponse) return;
         const { status } = TlvStatusResponse.decode(payload);
         if (status !== StatusCode.Success) throw new StatusResponseError(`Received error status: ${ status }`, status);
-    }
-
-    close() {
-        this.exchangeBase.close();
     }
 }
 

--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -75,16 +75,8 @@ class InteractionMessenger<ContextT> {
     }
 
     async waitForSuccess() {
-        const response = await this.nextMessage(MessageType.StatusResponse);
-        this.throwIfError(response.payloadHeader.messageType, response.payload);
-    }
-
-    protected throwIfError(messageType: number, payload: ByteArray) {
-        if (messageType !== MessageType.StatusResponse) return;
-        const { status } = TlvStatusResponse.decode(payload);
-        if (status !== StatusCode.Success) {
-            throw new StatusResponseError(`Received error status: ${ status }`, status);
-        }
+        // If the status is not Success, this would throw an Error.
+        await this.nextMessage(MessageType.StatusResponse);
     }
 
     async nextMessage(expectedMessageType?: number) {
@@ -93,6 +85,12 @@ class InteractionMessenger<ContextT> {
         this.throwIfError(messageType, message.payload);
         if (expectedMessageType !== undefined && messageType !== expectedMessageType) throw new Error(`Received unexpected message type: ${messageType}, expected: ${expectedMessageType}`);
         return message;
+    }
+
+    protected throwIfError(messageType: number, payload: ByteArray) {
+        if (messageType !== MessageType.StatusResponse) return;
+        const { status } = TlvStatusResponse.decode(payload);
+        if (status !== StatusCode.Success) throw new StatusResponseError(`Received error status: ${ status }`, status);
     }
 
     close() {

--- a/src/matter/session/secure/SecureChannelMessenger.ts
+++ b/src/matter/session/secure/SecureChannelMessenger.ts
@@ -5,10 +5,10 @@
  */
 
 import { MessageExchange } from "../../common/MessageExchange";
-import {GeneralStatusCode, ProtocolStatusCode, MessageType, SECURE_CHANNEL_PROTOCOL_ID} from "./SecureChannelMessages";
+import { GeneralStatusCode, ProtocolStatusCode, MessageType, SECURE_CHANNEL_PROTOCOL_ID } from "./SecureChannelMessages";
 import { ByteArray, TlvSchema } from "@project-chip/matter.js";
 import { MatterError } from "../../../error/MatterError";
-import { SecureChannelStatusMessageSchema } from "./SecureChannelStatusMessageSchema";
+import { TlvSecureChannelStatusMessage } from "./SecureChannelStatusMessageSchema";
 
 /** Error base Class for all errors related to the status response messages. */
 export class ChannelStatusResponseError extends MatterError {
@@ -66,8 +66,7 @@ export class SecureChannelMessenger<ContextT> {
     }
 
     private async sendStatusReport(generalStatus: GeneralStatusCode, protocolStatus: ProtocolStatusCode) {
-        const statusReportSchema = new SecureChannelStatusMessageSchema();
-        await this.exchange.send(MessageType.StatusReport, statusReportSchema.encode({
+        await this.exchange.send(MessageType.StatusReport, TlvSecureChannelStatusMessage.encode({
             generalStatus,
             protocolId: SECURE_CHANNEL_PROTOCOL_ID,
             protocolStatus
@@ -77,8 +76,7 @@ export class SecureChannelMessenger<ContextT> {
     protected throwIfError(messageType: number, payload: ByteArray) {
         if (messageType !== MessageType.StatusReport) return;
 
-        const statusReportSchema = new SecureChannelStatusMessageSchema();
-        const { generalStatus, protocolId, protocolStatus } = statusReportSchema.decode(payload);
+        const { generalStatus, protocolId, protocolStatus } = TlvSecureChannelStatusMessage.decode(payload);
         if (generalStatus !== GeneralStatusCode.Success) {
             throw new ChannelStatusResponseError(`Received general error status (${protocolId})`, generalStatus, protocolStatus);
         }

--- a/src/matter/session/secure/SecureChannelMessenger.ts
+++ b/src/matter/session/secure/SecureChannelMessenger.ts
@@ -38,7 +38,8 @@ export class SecureChannelMessenger<ContextT> {
     }
 
     async waitForSuccess() {
-        await this.nextMessage(MessageType.StatusReport); // this also throws if the status is not success
+        // If the status is not Success, this would throw an Error.
+        await this.nextMessage(MessageType.StatusReport);
     }
 
     async send<T>(message: T, type: number, schema: TlvSchema<T>) {

--- a/src/matter/session/secure/SecureChannelStatusMessageSchema.ts
+++ b/src/matter/session/secure/SecureChannelStatusMessageSchema.ts
@@ -4,21 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ByteArray, DataReader, DataWriter, Endian } from "@project-chip/matter.js";
-import { GeneralStatusCode, ProtocolStatusCode, SECURE_CHANNEL_PROTOCOL_ID } from "./SecureChannelMessages";
+import { ByteArray, DataReader, DataWriter, Endian, Schema } from "@project-chip/matter.js";
+import { GeneralStatusCode, ProtocolStatusCode } from "./SecureChannelMessages";
 
-export function decodeStatusReport(payload: ByteArray) {
-    const reader = new DataReader(payload, Endian.Little);
-    const generalStatus = reader.readUInt16();
-    const protocolId = reader.readUInt32();
-    const protocolStatus = reader.readUInt16();
-    return { generalStatus, protocolId, protocolStatus };
+export type StatusMessage = {
+    generalStatus: GeneralStatusCode;
+    protocolId: number;
+    protocolStatus: ProtocolStatusCode;
 }
 
-export function encodeStatusReport(generalStatus: GeneralStatusCode, protocolStatus: ProtocolStatusCode) {
-    const writer = new DataWriter(Endian.Little);
-    writer.writeUInt16(generalStatus);
-    writer.writeUInt32(SECURE_CHANNEL_PROTOCOL_ID);
-    writer.writeUInt16(protocolStatus);
-    return writer.toByteArray();
+export class SecureChannelStatusMessageSchema extends Schema<StatusMessage, ByteArray> {
+    encodeInternal({ generalStatus, protocolId, protocolStatus }: StatusMessage) {
+        const writer = new DataWriter(Endian.Little);
+        writer.writeUInt16(generalStatus);
+        writer.writeUInt32(protocolId);
+        writer.writeUInt16(protocolStatus);
+        return writer.toByteArray();
+    }
+
+    decodeInternal(bytes: ByteArray) {
+        const reader = new DataReader(bytes, Endian.Little);
+        const generalStatus = reader.readUInt16();
+        const protocolId = reader.readUInt32();
+        const protocolStatus = reader.readUInt16();
+        return { generalStatus, protocolId, protocolStatus };
+    }
 }

--- a/src/matter/session/secure/SecureChannelStatusMessageSchema.ts
+++ b/src/matter/session/secure/SecureChannelStatusMessageSchema.ts
@@ -30,3 +30,5 @@ export class SecureChannelStatusMessageSchema extends Schema<StatusMessage, Byte
         return { generalStatus, protocolId, protocolStatus };
     }
 }
+
+export const TlvSecureChannelStatusMessage = new SecureChannelStatusMessageSchema();

--- a/src/matter/session/secure/SecureChannelStatusMessageSchema.ts
+++ b/src/matter/session/secure/SecureChannelStatusMessageSchema.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ByteArray, DataReader, DataWriter, Endian } from "@project-chip/matter.js";
+import { GeneralStatusCode, ProtocolStatusCode, SECURE_CHANNEL_PROTOCOL_ID } from "./SecureChannelMessages";
+
+export function decodeStatusReport(payload: ByteArray) {
+    const reader = new DataReader(payload, Endian.Little);
+    const generalStatus = reader.readUInt16();
+    const protocolId = reader.readUInt32();
+    const protocolStatus = reader.readUInt16();
+    return { generalStatus, protocolId, protocolStatus };
+}
+
+export function encodeStatusReport(generalStatus: GeneralStatusCode, protocolStatus: ProtocolStatusCode) {
+    const writer = new DataWriter(Endian.Little);
+    writer.writeUInt16(generalStatus);
+    writer.writeUInt32(SECURE_CHANNEL_PROTOCOL_ID);
+    writer.writeUInt16(protocolStatus);
+    return writer.toByteArray();
+}


### PR DESCRIPTION
This PR uses the new Error classes to instoduce StatusError classes that are thrown when an unexpected StatusCode is returned.

This also fixes the "waitForSucces" to really wait for a success reswponse and not for "any" response