### PR TITLE
Catch StatusResponse exceptions on invoke and send this status

### DIFF
--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -157,7 +157,7 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                 logger.info(`Sending status response ${error.code} for interaction error: ${error}`);
                 await this.sendStatus(error.code);
             } else {
-                logger.error(error.stack ?? error);
+                logger.error(error);
                 await this.sendStatus(StatusCode.Failure);
             }
         } finally {

--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -153,14 +153,13 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
                 }
             }
         } catch (error: any) {
-            let statusCode = StatusCode.Failure;
             if (error instanceof StatusResponseError) {
-                statusCode = error.code;
+                logger.info(`Sending status response ${error.code} for interaction error: ${error}`);
+                await this.sendStatus(error.code);
             } else {
                 logger.error(error.stack ?? error);
+                await this.sendStatus(StatusCode.Failure);
             }
-            logger.info(`Sending status response ${statusCode} for interaction error: ${error}`);
-            await this.sendStatus(statusCode);
         } finally {
             this.exchange.close();
         }


### PR DESCRIPTION
This PR uses the option that a invoked command can throw a "StatusResponseError" with a defined code and when this code is used and send out.

I decided to not use the tryCatch approach here because the error handler needs to be async and needs to await the Status send action (the alternative would be strange code in my eyes).