### PR TITLE
Initialize Secure Case Session earlier

### DIFF
--- a/src/matter/session/secure/CaseServer.ts
+++ b/src/matter/session/secure/CaseServer.ts
@@ -45,10 +45,16 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
         // Try to resume a previous session
         const resumptionId = Crypto.getRandomData(16);
         let resumptionRecord;
+
+        // We try to resume the session
         if (peerResumptionId !== undefined && peerResumeMic !== undefined && (resumptionRecord = server.findResumptionRecordById(peerResumptionId)) !== undefined) {
             const { sharedSecret, fabric, peerNodeId } = resumptionRecord;
             const peerResumeKey = await Crypto.hkdf(sharedSecret, ByteArray.concat(peerRandom, peerResumptionId), KDFSR1_KEY_INFO);
             Crypto.decrypt(peerResumeKey, peerResumeMic, RESUME1_MIC_NONCE);
+
+            // All good! Create secure session
+            const secureSessionSalt = ByteArray.concat(peerRandom, peerResumptionId);
+            const secureSession = await server.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, secureSessionSalt, false, true, mrpParams?.idleRetransTimeoutMs, mrpParams?.activeRetransTimeoutMs);
 
             // Generate sigma 2 resume
             const resumeSalt = ByteArray.concat(peerRandom, resumptionId);
@@ -56,9 +62,6 @@ export class CaseServer implements ProtocolHandler<MatterDevice> {
             const resumeMic = Crypto.encrypt(resumeKey, new ByteArray(0), RESUME2_MIC_NONCE);
             await messenger.sendSigma2Resume({ resumptionId, resumeMic, sessionId });
 
-            // All good! Create secure session
-            const secureSessionSalt = ByteArray.concat(peerRandom, peerResumptionId);
-            const secureSession = await server.createSecureSession(sessionId, fabric, peerNodeId, peerSessionId, sharedSecret, secureSessionSalt, false, true, mrpParams?.idleRetransTimeoutMs, mrpParams?.activeRetransTimeoutMs);
             logger.info(`Case server: session ${secureSession.getId()} resumed with ${messenger.getChannelName()}`);
             resumptionRecord.resumptionId = resumptionId; /* Update the ID */
 


### PR DESCRIPTION
This PR initialize the SecureSession instance a bit earlier because we send the sessionId already out as Sigma2Resule before we initialize the session, WHile playing around I had edge cases where the peer sent in requests with the new ID before we had registered the session id internally in the SessionManager. 

Moving the code solvs this. The worst case is that Sigma2Result fails (which can normally only happen in network issue cases) and we have the session object created which is then not used