### PR TITLE
Return correct status for unsupported Attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@project-chip/matter.js": "^0.1.0",
+        "@project-chip/matter.js": "^0.2.0",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4"
       },
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@project-chip/matter.js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.1.0.tgz",
-      "integrity": "sha512-qJ/0OlrfHCE6AQqOZW+YQHePnTVzwBwbiifPELcZ8I4B09i22HGVcHNlpN/AktMkB31yoX7zVU52qqqOTuExLw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.2.0.tgz",
+      "integrity": "sha512-v0UOYLf4IAa3tGP9NqWM929Y5a25OPY5WuNjn5bSdD6FN8HfCNWeAvtmOEeI37YnYcYtcFz4X8QjSh8rDcK1nw=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -1228,9 +1228,9 @@
       }
     },
     "@project-chip/matter.js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.1.0.tgz",
-      "integrity": "sha512-qJ/0OlrfHCE6AQqOZW+YQHePnTVzwBwbiifPELcZ8I4B09i22HGVcHNlpN/AktMkB31yoX7zVU52qqqOTuExLw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.2.0.tgz",
+      "integrity": "sha512-v0UOYLf4IAa3tGP9NqWM929Y5a25OPY5WuNjn5bSdD6FN8HfCNWeAvtmOEeI37YnYcYtcFz4X8QjSh8rDcK1nw=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@project-chip/matter.js": "^0.2.0",
+        "@project-chip/matter.js": "^0.2.1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4"
       },
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@project-chip/matter.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.2.0.tgz",
-      "integrity": "sha512-v0UOYLf4IAa3tGP9NqWM929Y5a25OPY5WuNjn5bSdD6FN8HfCNWeAvtmOEeI37YnYcYtcFz4X8QjSh8rDcK1nw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.2.1.tgz",
+      "integrity": "sha512-u12jt5HRIm1W1jwE+1stl3gMW/8jSC/1/yKYS01KL3+XAATJ2kiQifCVqPUjH+92N8Bt7xM63zAVBiX4T7f0JA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -1228,9 +1228,9 @@
       }
     },
     "@project-chip/matter.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.2.0.tgz",
-      "integrity": "sha512-v0UOYLf4IAa3tGP9NqWM929Y5a25OPY5WuNjn5bSdD6FN8HfCNWeAvtmOEeI37YnYcYtcFz4X8QjSh8rDcK1nw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.2.1.tgz",
+      "integrity": "sha512-u12jt5HRIm1W1jwE+1stl3gMW/8jSC/1/yKYS01KL3+XAATJ2kiQifCVqPUjH+92N8Bt7xM63zAVBiX4T7f0JA=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@project-chip/matter.js": "^0.1.0",
+    "@project-chip/matter.js": "^0.2.0",
     "bn.js": "^5.2.0",
     "elliptic": "^6.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@project-chip/matter.js": "^0.2.0",
+    "@project-chip/matter.js": "^0.2.1",
     "bn.js": "^5.2.0",
     "elliptic": "^6.5.4"
   },

--- a/src/matter/interaction/InteractionClient.ts
+++ b/src/matter/interaction/InteractionClient.ts
@@ -94,7 +94,9 @@ export class InteractionClient {
                 isFabricFiltered: true,
             });
 
-            return response.values.map(({ value: { path: {endpointId, clusterId, attributeId}, version, value }}) => {
+            return response.values.flatMap(({ value: reportValue} ) => {
+                if (reportValue === undefined) return [];
+                const { path: { endpointId, clusterId, attributeId }, version, value } = reportValue;
                 if (endpointId === undefined || clusterId === undefined || attributeId === undefined ) throw new Error("Invalid response");
                 return { endpointId, clusterId, attributeId, version, value };
             });
@@ -109,7 +111,13 @@ export class InteractionClient {
                 isFabricFiltered: true,
             });
 
-            const value = response.values.map(({value}) => value).find(({ path }) => endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId);
+            const value = response.values.map(({ value }) => value).find((value) => {
+                if (value === undefined) return false;
+                const { path } = value;
+                return endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId;
+            });
+            // Todo add proper handling for returned attributeStatus information
+
             if (value === undefined) {
                 if (optional) return undefined;
                 if (conformanceValue === undefined) throw new Error(`Attribute ${endpointId}/${clusterId}/${id} not found`);
@@ -141,7 +149,11 @@ export class InteractionClient {
             }); // TODO: also initialize all values
 
             const subscriptionListener = (dataReport: DataReport) => {
-                const value = dataReport.values.map(({value}) => value).find(({ path }) => endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId);
+                const value = dataReport.values.map(({ value }) => value).find((value) => {
+                    if (value === undefined) return false;
+                    const { path } = value;
+                    return endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId;
+                });
                 if (value === undefined) return;
                 listener(schema.decodeTlv(value.value), value.version);
             };

--- a/src/matter/interaction/InteractionClient.ts
+++ b/src/matter/interaction/InteractionClient.ts
@@ -93,6 +93,9 @@ export class InteractionClient {
                 interactionModelRevision: 1,
                 isFabricFiltered: true,
             });
+            if (!Array.isArray(response.values)) {
+                return []; // TODO handle Errors correctly
+            }
 
             return response.values.flatMap(({ value: reportValue} ) => {
                 if (reportValue === undefined) return [];
@@ -111,12 +114,15 @@ export class InteractionClient {
                 isFabricFiltered: true,
             });
 
-            const value = response.values.map(({ value }) => value).find((value) => {
-                if (value === undefined) return false;
-                const { path } = value;
-                return endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId;
-            });
-            // Todo add proper handling for returned attributeStatus information
+            let value;
+            if (Array.isArray(response.values)) {
+                value = response.values.map(({ value }) => value).find((value) => {
+                    if (value === undefined) return false;
+                    const { path } = value;
+                    return endpointId === path.endpointId && clusterId === path.clusterId && id === path.attributeId;
+                });
+                // Todo add proper handling for returned attributeStatus information
+            }
 
             if (value === undefined) {
                 if (optional) return undefined;
@@ -149,6 +155,9 @@ export class InteractionClient {
             }); // TODO: also initialize all values
 
             const subscriptionListener = (dataReport: DataReport) => {
+                if (!Array.isArray(dataReport.values)) {
+                    return;
+                }
                 const value = dataReport.values.map(({ value }) => value).find((value) => {
                     if (value === undefined) return false;
                     const { path } = value;

--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -134,7 +134,7 @@ export const TlvAttributeReportValue = TlvObject({ // TODO consolidate with TlvA
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.5 */
 export const TlvAttributeReport = TlvObject({ // AttributeReportIB
     attributeStatus: TlvOptionalField(0, TlvAttributeStatus),
-    value: TlvOptionalField(1, TlvAttributeReportValue), // AttributeDataIB, TODO rename to attributeData, formally Optional?
+    value: TlvOptionalField(1, TlvAttributeReportValue), // AttributeDataIB, TODO rename to attributeData
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.15 */
@@ -200,8 +200,8 @@ export const TlvReadRequest = TlvObject({
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.3 */
 export const TlvDataReport = TlvObject({
     subscriptionId: TlvOptionalField(0, TlvUInt32),
-    values: TlvField(1, TlvArray(TlvAttributeReport), []), // TODO: rename to attributeReports, formally optional
-    eventReports: TlvOptionalField(2, TlvArray(TlvEventReport)), // TODO: rename to attributeReports, formally optional
+    values: TlvOptionalField(1, TlvArray(TlvAttributeReport)), // TODO: rename to attributeReports
+    eventReports: TlvOptionalField(2, TlvArray(TlvEventReport)),
     moreChunkedMessages: TlvOptionalField(3, TlvBoolean),
     suppressResponse: TlvOptionalField(4, TlvBoolean),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),

--- a/src/matter/interaction/InteractionMessages.ts
+++ b/src/matter/interaction/InteractionMessages.ts
@@ -134,7 +134,7 @@ export const TlvAttributeReportValue = TlvObject({ // TODO consolidate with TlvA
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.5 */
 export const TlvAttributeReport = TlvObject({ // AttributeReportIB
     attributeStatus: TlvOptionalField(0, TlvAttributeStatus),
-    value: TlvField(1, TlvAttributeReportValue), // AttributeDataIB, TODO rename to attributeData, formally Optional
+    value: TlvOptionalField(1, TlvAttributeReportValue), // AttributeDataIB, TODO rename to attributeData, formally Optional?
 });
 
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.5.15 */
@@ -200,8 +200,8 @@ export const TlvReadRequest = TlvObject({
 /** @see {@link MatterCoreSpecificationV1_0}, section 10.6.3 */
 export const TlvDataReport = TlvObject({
     subscriptionId: TlvOptionalField(0, TlvUInt32),
-    values: TlvField(1, TlvArray(TlvAttributeReport)), // TODO: rename to attributeReports, formally optional
-    eventReports: TlvOptionalField(2, TlvArray(TlvEventReport)),
+    values: TlvField(1, TlvArray(TlvAttributeReport), []), // TODO: rename to attributeReports, formally optional
+    eventReports: TlvOptionalField(2, TlvArray(TlvEventReport)), // TODO: rename to attributeReports, formally optional
     moreChunkedMessages: TlvOptionalField(3, TlvBoolean),
     suppressResponse: TlvOptionalField(4, TlvBoolean),
     interactionModelRevision: TlvField(0xFF, TlvUInt8),

--- a/src/matter/interaction/InteractionMessenger.ts
+++ b/src/matter/interaction/InteractionMessenger.ts
@@ -158,6 +158,9 @@ export class InteractionServerMessenger extends InteractionMessenger<MatterDevic
 
     async sendDataReport(dataReport: DataReport) {
         const messageBytes = TlvDataReport.encode(dataReport);
+        if (!Array.isArray(dataReport.values)) {
+            throw new Error(`DataReport.values must be an array, got: ${dataReport.values}`);
+        }
         if (messageBytes.length > MAX_SPDU_LENGTH) {
             // DataReport is too long, it needs to be sent in chunks
             const attributeReportsToSend = [...dataReport.values];


### PR DESCRIPTION
This PR implements a correct response when reading unknown attributes by introducing the use of the "attributeStatus" field in DataReport structure. For now only UnknownAttribute is returned, other cases are still Todo.

The PR relies on merging https://github.com/project-chip/matter.js/pull/50 and releasing a new version of matter.js

This fix should unblock Smartthings and HomeAssistant commissioning